### PR TITLE
fix: resolve open security & code-scanning alerts (workflow perms, path traversal, SRI)

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/air-blackbox-telemetry/dashboard.html
+++ b/air-blackbox-telemetry/dashboard.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AIR Blackbox — Usage Dashboard</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.js" integrity="sha384-dug+JxfBvklEQdJ4AYuBBAIScUz0bVN73xpy273gcAwHjb3qI0fXmuYNaNfdyYJG" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {

--- a/dashboard/replay.py
+++ b/dashboard/replay.py
@@ -101,8 +101,16 @@ async def api_run(run_id: str):
     )
     if not matches:
         raise HTTPException(status_code=404, detail="run not found")
+
+    # Confirm the resolved path stays inside RUNS_DIR before opening it,
+    # so a crafted run_id can never escape the runs directory (path traversal).
+    record_path = os.path.realpath(matches[0])
+    runs_root = os.path.realpath(RUNS_DIR)
+    if os.path.commonpath([record_path, runs_root]) != runs_root:
+        raise HTTPException(status_code=400, detail="invalid run id")
+
     try:
-        with open(matches[0]) as f:
+        with open(record_path) as f:
             record = json.load(f)
     except (json.JSONDecodeError, OSError):
         raise HTTPException(status_code=500, detail="record unreadable")


### PR DESCRIPTION
## Summary

Addresses the open GitHub security & code-scanning alerts on `main`.

## Changes
- **Code scanning #1 & #2 (Workflow permissions)** — added a top-level `permissions: contents: read` block to `.github/workflows/compliance.yml` so both jobs run with least-privilege `GITHUB_TOKEN`.
- **Code scanning #4 (Path injection, High)** — `dashboard/replay.py`: after resolving the matched run file, verify the real path stays inside `RUNS_DIR` (via `os.path.realpath` + `os.path.commonpath`) before opening it. Defense-in-depth on top of the existing alphanumeric `run_id` validation.
- **Code scanning #5 (Untrusted CDN script)** — `air-blackbox-telemetry/dashboard.html`: added `integrity` (SHA-384, computed from the actual served file), `crossorigin="anonymous"`, and `referrerpolicy="no-referrer"` to the Chart.js CDN `<script>` tag.

## Not included (need follow-up)
- **Code scanning #3** (`tests/test_trust_layers.py`) — false positive: it's a test assertion (`assert "https://example.com" in text`), not sanitization logic. Recommend dismissing the alert rather than changing the test.
- **Dependabot #12** (`golang.org/x/net` DoS) — transitive via `minio-go` / OpenTelemetry exporter; Dependabot's auto-update fails due to incompatible constraints. Needs a `go mod tidy` with updated direct deps (can't regenerate `go.sum` hashes reliably via the web editor).

## Notes
Please review and merge if this looks good.