### PR TITLE
Product-wide review fixes, cross-language chain, lakehouse sink, compliance sandbox, config attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest cryptography
+        run: pip install pytest cryptography pyarrow
       - name: Test SDK
         run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+  python-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        run: pip install pytest cryptography
+      - name: Test SDK
+        run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
+
   fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest cryptography pyarrow
+        run: pip install pytest cryptography pyarrow pyyaml
       - name: Test SDK
         run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ air-blackbox discover
 # Replay any recorded episode
 air-blackbox replay
 
+# Verify the tamper-evident chain (zero config: reads the gateway's local key)
+air-blackbox replay --verify
+
 # Generate a signed evidence package for audit or regulator review
 air-blackbox export
 ```

--- a/README.md
+++ b/README.md
@@ -98,6 +98,31 @@ python3 dashboard/replay.py   # open http://localhost:8090
 
 To re-execute a recorded run against the provider and diff the behavior, use `replayctl replay <run.air.json>`.
 
+## AIR on the Lakehouse (preview)
+
+Land the audit chain next to your business data as an open-format Parquet
+dataset - queryable with Spark, DuckDB, or anything that reads Parquet, and
+still tamper-evident: chain verification runs directly over the table.
+
+```bash
+pip install air-blackbox[lake]
+
+air-blackbox lake export --runs-dir ./runs -o ./air-lake   # incremental Parquet export
+air-blackbox lake verify -o ./air-lake                     # HMAC chain walk over the table
+```
+
+```sql
+-- Your agent audit trail is now just a table:
+SELECT model, provider, count(*) AS calls, sum(tokens_total) AS tokens
+FROM read_parquet('air-lake/**/*.parquet')
+GROUP BY model, provider;
+```
+
+Each row carries flattened columns for SQL plus the record's exact JSON as
+the verified source of truth. Edit any row - the payload or the SQL columns -
+and `lake verify` reports exactly which record broke. The signing key never
+enters the lake.
+
 ## Deploy on Kubernetes
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ the verified source of truth. Edit any row - the payload or the SQL columns -
 and `lake verify` reports exactly which record broke. The signing key never
 enters the lake.
 
+To verify inside Databricks/Spark instead, use
+[docs/notebooks/verify_air_lake.py](docs/notebooks/verify_air_lake.py) - the
+chain walk needs only the rows and the key, on any engine.
+
+## Compliance Sandbox (preview)
+
+Agents graduate to production with a signed behavioral record. A sandbox
+session provisions an isolated gateway (fresh runs directory, locally
+generated signing key), points your agent at it via `OPENAI_BASE_URL`,
+records everything, and issues a PASS/FAIL verdict computed from the
+evidence - not the agent's word:
+
+```bash
+air-blackbox sandbox-run --gateway-bin ./gateway -- python my_agent.py
+```
+
+PASS requires: agent exited cleanly, every LLM call recorded and chained,
+chain verifies intact, zero errored calls. The session emits `report.json`,
+a Parquet lake dataset, and a signed `.air-evidence` bundle an approver can
+verify independently - the graduation certificate. Agents that bypass the
+gateway fail: no records, no graduation.
+
 ## Deploy on Kubernetes
 
 ```bash

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -160,6 +160,15 @@ func main() {
 		log.Println("Trust layer: disabled (enable in guardrails.yaml trust section)")
 	}
 
+	// --- Config attestation (opt-in) ---
+	// Set AIR_CONFIG_HASH (e.g. from `air-blackbox attest create`) to bind
+	// every record to the agent config bundle that produced it. Clients can
+	// override per request with the X-Air-Config-Hash header.
+	configHash := envOr("AIR_CONFIG_HASH", "")
+	if configHash != "" {
+		log.Printf("Config attestation: %s", configHash)
+	}
+
 	// --- Proxy handler ---
 	handler := proxy.Handler(proxy.Config{
 		ProviderURL: *providerURL,
@@ -170,6 +179,7 @@ func main() {
 		Sessions:    grMgr,
 		Analytics:   analytics,
 		AuditChain:  auditChain,
+		ConfigHash:  configHash,
 	})
 
 	srv := &http.Server{

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -61,6 +62,12 @@ func main() {
 		log.Println("WARN: VAULT_ENDPOINT not set — vault storage disabled")
 	}
 
+	// --- Signing key resolution (env → guardrails config → generated keyfile) ---
+	// Used for both the on-disk record chain and the trust layer, so records
+	// are tamper-evident even when the trust layer is disabled.
+	signingKey := envOr("TRUST_SIGNING_KEY", "")
+	keySource := "TRUST_SIGNING_KEY"
+
 	// --- Recorder setup ---
 	rec, err := recorder.NewWriter(*runsDir)
 	if err != nil {
@@ -107,16 +114,47 @@ func main() {
 		log.Println("Optimization analytics: disabled")
 	}
 
+	// Finish key resolution now that the guardrails config is loaded.
+	if signingKey == "" && grCfg != nil && grCfg.Trust.SigningKey != "" {
+		signingKey = grCfg.Trust.SigningKey
+		keySource = "guardrails config"
+	}
+	if signingKey == "" {
+		keyPath := filepath.Join(*runsDir, ".air-signing-key")
+		signingKey, err = trust.LoadOrGenerateKey(keyPath)
+		if err != nil {
+			log.Fatalf("signing key: %v", err)
+		}
+		keySource = keyPath
+	}
+	log.Printf("Signing key: %s", keySource)
+
+	// --- Record chaining ---
+	// Every AIR record gets a chain_seq + chain_hash verifiable by the Python
+	// SDK (air-blackbox replay --verify) and the evidence bundle tooling.
+	if rec != nil {
+		resumedAt, err := rec.EnableChaining(signingKey)
+		if err != nil {
+			log.Printf("WARN: record chaining disabled: %v", err)
+		} else if resumedAt > 0 {
+			log.Printf("Record chain: resumed at sequence %d", resumedAt)
+		} else {
+			log.Println("Record chain: started")
+		}
+	}
+
 	// --- Trust layer setup (opt-in) ---
 	var auditChain *trust.AuditChain
 	if grCfg != nil && grCfg.Trust.Enabled {
-		signingKey := envOr("TRUST_SIGNING_KEY", grCfg.Trust.SigningKey)
-		if signingKey == "" {
-			log.Println("WARN: Trust layer enabled but no signing key set (set TRUST_SIGNING_KEY)")
-			signingKey = "insecure-default-key"
-		}
 		grCfg.Trust.SigningKey = signingKey // store resolved key for export endpoint
-		auditChain = trust.NewAuditChain(signingKey)
+		chainPath := filepath.Join(*runsDir, "audit-chain.jsonl")
+		auditChain, err = trust.NewPersistentAuditChain(signingKey, chainPath)
+		if err != nil {
+			log.Printf("WARN: audit chain persistence unavailable (%v); using in-memory chain", err)
+			auditChain = trust.NewAuditChain(signingKey)
+		} else {
+			log.Printf("Audit chain: persisted to %s (%d entries loaded)", chainPath, auditChain.Len())
+		}
 		log.Printf("Trust layer: enabled (frameworks: %v)", grCfg.Trust.Compliance.Frameworks)
 	} else {
 		log.Println("Trust layer: disabled (enable in guardrails.yaml trust section)")

--- a/dashboard/replay.py
+++ b/dashboard/replay.py
@@ -23,6 +23,7 @@ router = APIRouter()
 
 RUNS_DIR = os.environ.get("RUNS_DIR", "./runs")
 GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8080")
+GATEWAY_KEY = os.environ.get("GATEWAY_KEY", "")
 
 templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
 
@@ -45,9 +46,10 @@ def _load_runs(limit: int = 500) -> list[dict]:
 
 async def _chain_status() -> dict:
     """Fetch live audit chain verification from the gateway."""
+    headers = {"X-Gateway-Key": GATEWAY_KEY} if GATEWAY_KEY else {}
     try:
         async with httpx.AsyncClient(timeout=3.0) as client:
-            resp = await client.get(f"{GATEWAY_URL}/v1/audit")
+            resp = await client.get(f"{GATEWAY_URL}/v1/audit", headers=headers)
             if resp.status_code == 200:
                 data = resp.json()
                 return {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
       - RUNS_DIR=/data/runs
       - GUARDRAILS_CONFIG=/app/guardrails.yaml
+      # Optional: when unset, the gateway generates a random key and persists
+      # it as .air-signing-key in RUNS_DIR (survives restarts via the volume).
       - TRUST_SIGNING_KEY=${TRUST_SIGNING_KEY:-}
       # - GATEWAY_KEY=your-secret-key  # Uncomment to require authentication
     volumes:

--- a/docs/notebooks/verify_air_lake.py
+++ b/docs/notebooks/verify_air_lake.py
@@ -1,0 +1,114 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Verify the AIR Blackbox audit chain — in the lakehouse
+# MAGIC
+# MAGIC The AIR gateway records every LLM call as a tamper-evident, HMAC-chained
+# MAGIC record. `air-blackbox lake export` lands those records as a Parquet
+# MAGIC dataset. This notebook proves the chain **where the data lives**: no
+# MAGIC AIR install required, just the rows and the signing key.
+# MAGIC
+# MAGIC - **Chain walk** (sequential by construction): recomputes every record's
+# MAGIC   HMAC from `record_json`, ordered by `chain_seq`. Tampering with any
+# MAGIC   record breaks every record after it.
+# MAGIC - **Column consistency** (fully distributed): Spark SQL confirms the
+# MAGIC   flattened analytics columns agree with the verified `record_json`.
+# MAGIC
+# MAGIC The verifier below is the reference implementation from
+# MAGIC `docs/spec/audit-chain-v1.md` Section 6.2, byte-compatible with the Go
+# MAGIC gateway's writer and the Python SDK's `verify_records`.
+
+# COMMAND ----------
+
+dbutils.widgets.text("lake_path", "/Volumes/main/default/air_lake", "AIR lake dataset path")
+dbutils.widgets.text("signing_key_secret", "air/signing-key", "Secret scope/key for TRUST_SIGNING_KEY")
+
+LAKE_PATH = dbutils.widgets.get("lake_path")
+# Never hardcode the key in a notebook; pull it from a secret scope.
+scope, key_name = dbutils.widgets.get("signing_key_secret").split("/", 1)
+SIGNING_KEY = dbutils.secrets.get(scope, key_name).encode()
+
+# COMMAND ----------
+
+df = spark.read.parquet(LAKE_PATH)
+df.createOrReplaceTempView("air_records")
+display(spark.sql("""
+    SELECT model, provider, count(*) AS calls, sum(tokens_total) AS tokens,
+           avg(duration_ms) AS avg_ms
+    FROM air_records GROUP BY model, provider ORDER BY calls DESC
+"""))
+
+# COMMAND ----------
+
+# MAGIC %md ## 1. Chain walk (spec §6.2, verbatim)
+
+# COMMAND ----------
+
+import hashlib, hmac, json
+
+def verify_chain(records, signing_key):
+    errors, prev_digest, checked = [], b"genesis", 0
+    for i, record in enumerate(records):
+        stored_hash = record.get("chain_hash")
+        if not stored_hash:
+            continue  # unchained record: outside the chain
+        record_copy = {k: v for k, v in record.items() if k != "chain_hash"}
+        record_bytes = json.dumps(record_copy, sort_keys=True).encode("utf-8")
+        h = hmac.new(signing_key, prev_digest + record_bytes, hashlib.sha256)
+        if stored_hash != h.hexdigest():
+            errors.append(f"Record {i} ({record['run_id']}): chain_hash mismatch. "
+                          f"TAMPERING DETECTED (modified, deleted, or reordered).")
+            break
+        prev_digest = h.digest()
+        checked += 1
+    return {"valid": not errors, "events_checked": checked, "errors": errors}
+
+# The walk is inherently sequential (each hash depends on the previous
+# digest), so collect the payload column in chain order. One chain per
+# gateway replica: for multi-replica lakes, group by replica first.
+rows = (df.select("chain_seq", "timestamp", "record_json")
+          .orderBy("chain_seq", "timestamp")
+          .collect())
+records = [json.loads(r.record_json) for r in rows]
+
+result = verify_chain(records, SIGNING_KEY)
+print(result)
+assert result["valid"], "AUDIT CHAIN BROKEN - do not trust these records"
+
+# COMMAND ----------
+
+# MAGIC %md ## 2. Column consistency (distributed)
+# MAGIC The SQL columns must agree with the verified `record_json` payload,
+# MAGIC so neither layer can be edited independently.
+
+# COMMAND ----------
+
+mismatches = spark.sql("""
+    SELECT run_id, 'model' AS column, model AS column_value,
+           get_json_object(record_json, '$.model') AS record_value
+    FROM air_records
+    WHERE model != get_json_object(record_json, '$.model')
+    UNION ALL
+    SELECT run_id, 'tokens_total', cast(tokens_total AS string),
+           get_json_object(record_json, '$.tokens.total')
+    FROM air_records
+    WHERE tokens_total != cast(get_json_object(record_json, '$.tokens.total') AS bigint)
+    UNION ALL
+    SELECT run_id, 'chain_seq', cast(chain_seq AS string),
+           get_json_object(record_json, '$.chain_seq')
+    FROM air_records
+    WHERE chain_seq != cast(get_json_object(record_json, '$.chain_seq') AS bigint)
+    UNION ALL
+    SELECT run_id, 'status', status, get_json_object(record_json, '$.status')
+    FROM air_records
+    WHERE status != get_json_object(record_json, '$.status')
+""")
+n = mismatches.count()
+display(mismatches) if n else print("All analytics columns agree with the verified payload.")
+assert n == 0, f"{n} column(s) disagree with the verified record_json"
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ✅ **Both checks passed**: the audit trail in this table is complete,
+# MAGIC ordered, and untampered — provable by anyone with the rows and the key,
+# MAGIC on any engine. The signing key itself never enters the lake.

--- a/docs/spec/audit-chain-v1.md
+++ b/docs/spec/audit-chain-v1.md
@@ -120,9 +120,19 @@ Additional custom fields MAY be added by implementations, but MUST NOT override 
 The chain_hash for a record is computed using HMAC-SHA256 as follows:
 
 1. Sort all fields in the record alphabetically by key (excluding chain_hash itself).
-2. Serialize to JSON with no whitespace (canonical form).
-3. Compute HMAC-SHA256(signing_key, previous_hash_bytes || record_bytes).
+2. Serialize to canonical JSON: Python's `json.dumps(record, sort_keys=True)` with its
+   default separators (`", "` and `": "`) and default `ensure_ascii=True` escaping.
+3. Compute HMAC-SHA256(signing_key, previous_digest_bytes || record_bytes).
 4. Encode the result as hexadecimal (lowercase).
+
+The canonical form is exactly what Python's `json.dumps(record, sort_keys=True)`
+produces for a record round-tripped through `json.loads`. Non-Python
+implementations MUST reproduce it byte-for-byte: sorted keys, a space after
+every `,` and `:`, non-ASCII characters escaped as lowercase `\uXXXX` (astral
+code points as surrogate pairs), and integers preserved without float
+conversion. The Go gateway's `pkg/recorder/canonical.go` is a conforming
+implementation, locked down against Python-generated golden vectors in
+`pkg/recorder/canonical_test.go`.
 
 Pseudocode:
 
@@ -131,33 +141,35 @@ import hashlib
 import hmac
 import json
 
-def compute_chain_hash(signing_key, previous_hash, record):
-    # Remove chain_hash field if present
+def compute_chain_hash(signing_key, previous_digest, record):
+    # Remove chain_hash field if present. All other fields, including
+    # chain_seq, are covered by the hash.
     record_copy = {k: v for k, v in record.items() if k != "chain_hash"}
-    
-    # Canonical JSON: sorted keys, no whitespace
-    record_json = json.dumps(record_copy, sort_keys=True, separators=(",", ":"))
+
+    # Canonical JSON: sorted keys, default separators and escaping
+    record_json = json.dumps(record_copy, sort_keys=True)
     record_bytes = record_json.encode("utf-8")
-    
-    # Convert previous_hash to bytes
-    if previous_hash == "genesis":
-        prev_bytes = b"genesis"
-    else:
-        prev_bytes = bytes.fromhex(previous_hash)
-    
-    # HMAC-SHA256
-    h = hmac.new(signing_key, prev_bytes + record_bytes, hashlib.sha256)
-    return h.hexdigest()
+
+    # previous_digest is b"genesis" for the first record, otherwise the raw
+    # 32-byte HMAC digest of the previous chained record's computation
+    h = hmac.new(signing_key, previous_digest + record_bytes, hashlib.sha256)
+    return h.hexdigest(), h.digest()  # (stored chain_hash, next previous_digest)
 ```
 
-### 4.5 Previous Hash Linkage
+### 4.5 Previous Digest Linkage
 
-The previous_hash field creates the chain linkage:
+The previous digest creates the chain linkage. It is implicit walk state, not
+a field embedded in records:
 
-- **Genesis record**: previous_hash is the literal string "genesis" (not a computed value).
-- **Subsequent records**: previous_hash is the hex-encoded chain_hash of the preceding record.
+- **Genesis record**: the previous digest is the literal bytes `b"genesis"`.
+- **Subsequent records**: the previous digest is the raw 32-byte HMAC digest
+  from the preceding chained record's hash computation (equivalent to
+  `bytes.fromhex(previous_chain_hash)`).
 
-This linkage ensures that deleting or reordering records breaks the chain, making tampering detectable during verification.
+Writers advance this state on every successful chained write; verifiers
+recompute it while walking the chain in order. This linkage ensures that
+modifying, deleting, or reordering records breaks every chain_hash from that
+point forward, making tampering detectable during verification.
 
 ## 5. Record Fields Reference
 
@@ -193,12 +205,18 @@ This linkage ensures that deleting or reordering records breaks the chain, makin
 - MUST be set before persisting the record
 - MUST be verified during chain verification (Section 6)
 
-**previous_hash** (Hex String or "genesis", COMPUTED)
+**chain_seq** (Integer, COMPUTED, OPTIONAL)
 
-- Links this record to the previous record
-- For genesis: the literal string "genesis"
-- For all others: the hex-encoded chain_hash of the previous record
+- Monotonic append order (1-based) within one writer's chain
+- Written by the Go gateway so verifiers can reconstruct append order
+  regardless of timestamp precision or concurrent writes
+- Covered by the chain hash: it is part of the record when the hash is computed
+- When present, verifiers MUST walk the chain in ascending chain_seq order;
+  when absent, verifiers fall back to timestamp order
 - MUST NOT be set by the application; the chain implementation MUST compute it
+
+Note: the previous digest (Section 4.5) is implicit verification state and is
+NOT embedded in records.
 
 ### 5.3 Optional Context Fields
 
@@ -276,63 +294,56 @@ Chain verification confirms that no records have been tampered with, deleted, or
 
 ### 6.2 Step-by-Step Verification
 
+Verifiers MUST order records by ascending chain_seq when present, falling back
+to timestamp order for records written without it. Records that carry no
+chain_hash at all (written before chaining was enabled) are outside the chain:
+they MUST NOT advance the previous digest and MUST NOT be reported as verified.
+
 ```python
+import hashlib
+import hmac
+import json
+
 def verify_chain(records, signing_key):
     """
     Verify a chain of audit records.
-    
+
     Args:
-        records: List of records in order
+        records: List of records, ordered by (chain_seq, timestamp)
         signing_key: The HMAC signing key (bytes)
-    
+
     Returns:
         dict with keys:
             valid (bool): True if chain is intact
-            events_checked (int): Number of records verified
+            events_checked (int): Number of chained records verified
             errors (list): Any verification failures
     """
     errors = []
-    
-    if not records:
-        return {"valid": True, "events_checked": 0, "errors": []}
-    
-    # Verify each record
+    prev_digest = b"genesis"
+    checked = 0
+
     for i, record in enumerate(records):
-        # Check 1: Recompute the chain_hash
-        expected_hash = compute_chain_hash(
-            signing_key,
-            record["previous_hash"],
-            record
-        )
-        if record["chain_hash"] != expected_hash:
+        stored_hash = record.get("chain_hash")
+        if not stored_hash:
+            continue  # unchained record: outside the chain
+
+        record_copy = {k: v for k, v in record.items() if k != "chain_hash"}
+        record_bytes = json.dumps(record_copy, sort_keys=True).encode("utf-8")
+        h = hmac.new(signing_key, prev_digest + record_bytes, hashlib.sha256)
+
+        if stored_hash != h.hexdigest():
             errors.append(
                 f"Record {i} ({record['run_id']}): chain_hash mismatch. "
-                f"Expected {expected_hash}, got {record['chain_hash']}. "
-                f"TAMPERING DETECTED."
+                f"TAMPERING DETECTED (modified, deleted, or reordered)."
             )
-        
-        # Check 2: Verify previous_hash linkage
-        if i == 0:
-            # Genesis record must link to "genesis"
-            if record["previous_hash"] != "genesis":
-                errors.append(
-                    f"Record 0 ({record['run_id']}): genesis record must have "
-                    f"previous_hash='genesis', got '{record['previous_hash']}'"
-                )
-        else:
-            # All other records must link to the previous record's chain_hash
-            expected_prev = records[i - 1]["chain_hash"]
-            if record["previous_hash"] != expected_prev:
-                errors.append(
-                    f"Record {i} ({record['run_id']}): chain broken. "
-                    f"previous_hash should be {expected_prev}, got "
-                    f"{record['previous_hash']}. "
-                    f"Record may have been deleted or reordered."
-                )
-    
+            break  # every subsequent hash is invalidated too
+
+        prev_digest = h.digest()
+        checked += 1
+
     return {
         "valid": len(errors) == 0,
-        "events_checked": len(records),
+        "events_checked": checked,
         "errors": errors
     }
 ```
@@ -341,12 +352,12 @@ def verify_chain(records, signing_key):
 
 Tampering is detected when:
 
-1. **Modification**: A record's field is changed. The computed chain_hash will not match the stored value.
-2. **Deletion**: A record is removed from the middle of the chain. The next record's previous_hash will not match the preceding record's chain_hash.
-3. **Reordering**: Records are placed out of sequence. The previous_hash linkage will break.
-4. **Insertion**: A new record is inserted out of order. The following record's previous_hash will not match.
+1. **Modification**: A record's field is changed. The recomputed chain_hash will not match the stored value.
+2. **Deletion**: A record is removed from the middle of the chain. The verifier's previous digest diverges at that point, so the next record's chain_hash no longer verifies.
+3. **Reordering**: Records are placed out of sequence. The digest walk produces different hashes from the reorder point onward.
+4. **Insertion**: A record is inserted mid-chain. Its chain_hash cannot be computed without the signing key, and every subsequent record's hash breaks.
 
-All tampering is immediately detectable because previous_hash values create an unbreakable dependency chain.
+All tampering is immediately detectable because each chain_hash depends on the running digest of every record before it.
 
 ### 6.4 Error Handling
 
@@ -459,8 +470,18 @@ The signing key MUST be at least 32 bytes (256 bits). Implementations SHOULD use
 1. **Direct key**: A 32-byte random value (generated by `secrets.token_bytes(32)` in Python)
 2. **Key derivation**: PBKDF2-SHA256 from a passphrase (at least 100,000 iterations)
 3. **Key from environment**: The environment variable `TRUST_SIGNING_KEY` (RECOMMENDED for deployment)
+4. **Generated keyfile**: A locally generated random key persisted next to the
+   records as `.air-signing-key` with mode 0600. The Go gateway generates this
+   automatically when no key is configured, and verifiers read it back so
+   zero-configuration deployments still get unforgeable chains. The keyfile
+   MUST be excluded from backups shared with untrusted parties and MUST NOT be
+   committed to version control.
 
 Implementations MUST NOT use short passphrases, hardcoded keys, or md5/sha1 derived keys.
+
+The gateway resolves its key in this order: `TRUST_SIGNING_KEY` environment
+variable, then the guardrails config `trust.signing_key`, then the generated
+`.air-signing-key` file in the runs directory.
 
 ### 8.2 Key Rotation Procedure
 
@@ -487,7 +508,10 @@ signing_key = os.environ.get(
 )
 ```
 
-The default value MUST NOT be used in production. In production, `TRUST_SIGNING_KEY` MUST be set to a strong, random value.
+The default value MUST NOT be used in production. In production, set
+`TRUST_SIGNING_KEY` to a strong random value, or let the gateway generate and
+persist a `.air-signing-key` file (Section 8.1) — the generated keyfile is a
+production-grade key; the hardcoded development default is not.
 
 ## 9. Security Considerations
 

--- a/docs/spec/audit-chain-v1.md
+++ b/docs/spec/audit-chain-v1.md
@@ -238,6 +238,17 @@ NOT embedded in records.
 - Examples: "agent_start", "tool_call", "email_send", "database_write", "file_access"
 - Used for filtering and analysis
 
+**config_hash** (Hex String, OPTIONAL)
+
+- SHA-256 of the agent's attested config bundle (prompts, skills, covenants),
+  produced by `air-blackbox attest create` and stamped by the gateway from
+  the `AIR_CONFIG_HASH` environment variable or the `X-Air-Config-Hash`
+  request header
+- Covered by chain_hash, so chained records bind each call to the exact
+  configuration that produced it
+- Verifiers resolve it against the config manifest to identify which file
+  changed after an incident
+
 **tokens** (Integer, OPTIONAL)
 
 - Number of tokens consumed or generated

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -110,10 +110,21 @@ func authenticateGateway(w http.ResponseWriter, r *http.Request, gatewayKey stri
 }
 
 // chatRequest is the minimal OpenAI chat completion request we need to parse.
+// Input carries the Responses API equivalent of Messages.
 type chatRequest struct {
 	Model    string          `json:"model"`
 	Messages json.RawMessage `json:"messages"`
+	Input    json.RawMessage `json:"input"`
 	Stream   bool            `json:"stream,omitempty"`
+}
+
+// promptText returns the last user prompt regardless of API shape: chat
+// completions carry it in messages, the Responses API in input.
+func (r chatRequest) promptText() string {
+	if text := extractPromptText(r.Messages); text != "" {
+		return text
+	}
+	return extractResponsesInput(r.Input)
 }
 
 // chatResponse is the minimal response structure for token extraction.
@@ -173,7 +184,7 @@ func handleProxy(w http.ResponseWriter, r *http.Request, cfg Config, endpoint st
 	// model downgrade) or block entirely. Returns 403 for policy blocks.
 	if cfg.Guardrails != nil {
 		sessionID := extractSessionID(r)
-		promptText := extractPromptText(req.Messages)
+		promptText := req.promptText()
 		toolNames := extractToolNames(reqBody)
 		sessionTokens := 0
 		if cfg.Sessions != nil {
@@ -234,7 +245,7 @@ func handleProxy(w http.ResponseWriter, r *http.Request, cfg Config, endpoint st
 		sessionID := extractSessionID(r)
 		cfg.Sessions.GetOrCreate(sessionID)
 
-		promptText := extractPromptText(req.Messages)
+		promptText := req.promptText()
 		toolNames := extractToolNames(reqBody)
 		cfg.Sessions.RecordRequest(sessionID, promptText, toolNames)
 
@@ -642,6 +653,47 @@ func extractPromptText(messages json.RawMessage) string {
 					if p.Type == "text" {
 						return p.Text
 					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractResponsesInput pulls the last user prompt from a Responses API
+// input field, which is either a plain string or an array of messages whose
+// content is a string or an array of typed parts.
+func extractResponsesInput(input json.RawMessage) string {
+	if input == nil {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(input, &text); err == nil {
+		return text
+	}
+	var items []struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(input, &items); err != nil {
+		return ""
+	}
+	for i := len(items) - 1; i >= 0; i-- {
+		if items[i].Role != "user" {
+			continue
+		}
+		var content string
+		if err := json.Unmarshal(items[i].Content, &content); err == nil {
+			return content
+		}
+		var parts []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(items[i].Content, &parts); err == nil {
+			for _, p := range parts {
+				if p.Type == "input_text" || p.Type == "text" {
+					return p.Text
 				}
 			}
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -43,6 +43,7 @@ type Config struct {
 	Sessions    *guardrails.Manager // session state for guardrails (nil = disabled)
 	Analytics   *guardrails.PerformanceTracker // optimization analytics (nil = disabled)
 	AuditChain  *trust.AuditChain  // cryptographic audit chain (nil = disabled)
+	ConfigHash  string             // agent config bundle hash stamped into records ("" = unset)
 }
 
 // Handler returns an http.Handler that proxies OpenAI-compatible requests.
@@ -140,6 +141,12 @@ type chatResponse struct {
 
 func handleProxy(w http.ResponseWriter, r *http.Request, cfg Config, endpoint string) {
 	start := time.Now()
+
+	// Per-request config attestation overrides the gateway-wide hash.
+	// cfg is a value copy, so this mutation is request-local.
+	if h := r.Header.Get("X-Air-Config-Hash"); h != "" {
+		cfg.ConfigHash = h
+	}
 
 	// Generate run ID.
 	runID := uuid.New().String()
@@ -519,7 +526,7 @@ func backgroundRecord(cfg Config, runID string, span trace.Span,
 
 	// Write AIR record (best-effort).
 	writeAIRRecord(cfg.Recorder, runID, span, model, provider, endpoint,
-		reqRef, respRef, tokens, start, status, errMsg)
+		reqRef, respRef, tokens, start, status, errMsg, cfg.ConfigHash)
 
 	// Append to cryptographic audit chain (best-effort).
 	if cfg.AuditChain != nil {
@@ -576,7 +583,7 @@ func vaultStore(ctx context.Context, vc *vault.Client, runID, name string, data 
 }
 
 func writeAIRRecord(w *recorder.Writer, runID string, span trace.Span, model, provider, endpoint string,
-	reqRef, respRef vault.Ref, tokens recorder.Tokens, start time.Time, status, errMsg string) {
+	reqRef, respRef vault.Ref, tokens recorder.Tokens, start time.Time, status, errMsg, configHash string) {
 
 	if w == nil {
 		return
@@ -602,6 +609,7 @@ func writeAIRRecord(w *recorder.Writer, runID string, span trace.Span, model, pr
 		DurationMS:       time.Since(start).Milliseconds(),
 		Status:           status,
 		Error:            errMsg,
+		ConfigHash:       configHash,
 	}
 
 	if err := w.Write(rec); err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -101,7 +102,7 @@ func authenticateGateway(w http.ResponseWriter, r *http.Request, gatewayKey stri
 	if provided == "" {
 		provided = r.Header.Get("X-Api-Key")
 	}
-	if provided != gatewayKey {
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(gatewayKey)) != 1 {
 		http.Error(w, `{"error":"unauthorized: invalid or missing gateway key"}`, http.StatusUnauthorized)
 		return false
 	}
@@ -309,25 +310,27 @@ func handleProxy(w http.ResponseWriter, r *http.Request, cfg Config, endpoint st
 	}
 
 	// --- Streaming vs non-streaming response handling ---
-	if req.Stream && resp.Header.Get("Content-Type") == "text/event-stream" {
-		handleStreamingResponse(w, resp, cfg, runID, span, req, provider, endpoint, reqBody, start)
+	var tokens recorder.Tokens
+	if req.Stream && strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		tokens = handleStreamingResponse(w, resp, cfg, runID, span, req, provider, endpoint, reqBody, start)
 	} else {
-		handleBufferedResponse(w, resp, cfg, runID, span, req, provider, endpoint, reqBody, start)
+		tokens = handleBufferedResponse(w, resp, cfg, runID, span, req, provider, endpoint, reqBody, start)
 	}
 
 	// Update guardrails session state after response.
 	if cfg.Guardrails != nil && cfg.Sessions != nil {
 		sessionID := extractSessionID(r)
 		isError := resp.StatusCode >= 400
-		cfg.Sessions.RecordResponse(sessionID, 0, isError)
+		cfg.Sessions.RecordResponse(sessionID, tokens.Total, isError)
 	}
 }
 
 // handleStreamingResponse forwards SSE chunks to the client in real-time while
 // capturing the full response in the background for vault storage.
+// It returns the token usage extracted from the stream (zero if unavailable).
 func handleStreamingResponse(w http.ResponseWriter, resp *http.Response,
 	cfg Config, runID string, span trace.Span, req chatRequest,
-	provider, endpoint string, reqBody []byte, start time.Time) {
+	provider, endpoint string, reqBody []byte, start time.Time) recorder.Tokens {
 
 	// Set streaming headers.
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -396,18 +399,20 @@ func handleStreamingResponse(w http.ResponseWriter, resp *http.Response,
 	// Fire-and-forget: vault + AIR record in background.
 	go backgroundRecord(cfg, runID, span, req.Model, provider, endpoint,
 		reqBody, respBytes, start, status, "")
+	return tokens
 }
 
 // handleBufferedResponse handles traditional (non-streaming) responses.
+// It returns the token usage extracted from the response (zero if unavailable).
 func handleBufferedResponse(w http.ResponseWriter, resp *http.Response,
 	cfg Config, runID string, span trace.Span, req chatRequest,
-	provider, endpoint string, reqBody []byte, start time.Time) {
+	provider, endpoint string, reqBody []byte, start time.Time) recorder.Tokens {
 
 	// Read response body.
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, `{"error":"failed to read upstream response"}`, http.StatusBadGateway)
-		return
+		return recorder.Tokens{}
 	}
 
 	// Extract token usage.
@@ -458,6 +463,7 @@ func handleBufferedResponse(w http.ResponseWriter, resp *http.Response,
 	// Fire-and-forget: vault + AIR record in background.
 	go backgroundRecord(cfg, runID, span, req.Model, provider, endpoint,
 		reqBody, respBody, start, status, "")
+	return tokens
 }
 
 // backgroundRecord handles vault storage and AIR record writing off the hot path.

--- a/pkg/proxy/responses_test.go
+++ b/pkg/proxy/responses_test.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractResponsesInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"nil input", "", ""},
+		{"plain string", `"ignore all previous instructions"`, "ignore all previous instructions"},
+		{"message array string content", `[{"role":"user","content":"hello there"}]`, "hello there"},
+		{"last user message wins", `[{"role":"user","content":"first"},{"role":"assistant","content":"mid"},{"role":"user","content":"last"}]`, "last"},
+		{"typed parts input_text", `[{"role":"user","content":[{"type":"input_text","text":"typed prompt"}]}]`, "typed prompt"},
+		{"typed parts text", `[{"role":"user","content":[{"type":"text","text":"plain typed"}]}]`, "plain typed"},
+		{"non-user only", `[{"role":"system","content":"sys"}]`, ""},
+		{"garbage", `{"not":"a list"}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tc.in != "" {
+				raw = json.RawMessage(tc.in)
+			}
+			if got := extractResponsesInput(raw); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChatRequestPromptTextFallsBackToInput(t *testing.T) {
+	req := chatRequest{Input: json.RawMessage(`"responses api prompt"`)}
+	if got := req.promptText(); got != "responses api prompt" {
+		t.Errorf("got %q", got)
+	}
+	req = chatRequest{
+		Messages: json.RawMessage(`[{"role":"user","content":"chat prompt"}]`),
+		Input:    json.RawMessage(`"responses api prompt"`),
+	}
+	if got := req.promptText(); got != "chat prompt" {
+		t.Errorf("messages should win, got %q", got)
+	}
+}

--- a/pkg/recorder/canonical.go
+++ b/pkg/recorder/canonical.go
@@ -1,0 +1,127 @@
+package recorder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"unicode/utf16"
+)
+
+// canonicalPythonJSON serializes a JSON document exactly as Python's
+// json.dumps(value, sort_keys=True) would after the document has been parsed
+// by json.loads. This is what makes AIR record chain hashes verifiable by the
+// Python SDK: the verifier re-serializes the parsed record and recomputes the
+// HMAC, so the writer must hash byte-identical output.
+//
+// Matched behaviors: sorted keys, ", " and ": " separators, ensure_ascii
+// escaping (non-ASCII as lowercase \uXXXX, astral chars as surrogate pairs),
+// short escapes for \b \t \n \f \r, and integer preservation via json.Number.
+func canonicalPythonJSON(data []byte) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var v interface{}
+	if err := dec.Decode(&v); err != nil {
+		return nil, fmt.Errorf("canonical: parse: %w", err)
+	}
+
+	return canonicalValue(v)
+}
+
+// canonicalValue serializes an already-parsed JSON value (maps, slices,
+// json.Number, string, bool, nil) in Python's canonical form.
+func canonicalValue(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := writeCanonical(&buf, v); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func writeCanonical(buf *bytes.Buffer, v interface{}) error {
+	switch val := v.(type) {
+	case nil:
+		buf.WriteString("null")
+	case bool:
+		if val {
+			buf.WriteString("true")
+		} else {
+			buf.WriteString("false")
+		}
+	case json.Number:
+		// Emit the number exactly as it appeared in the source JSON; both
+		// sides round-trip integers and short decimals unchanged.
+		buf.WriteString(string(val))
+	case string:
+		writePythonString(buf, val)
+	case []interface{}:
+		buf.WriteByte('[')
+		for i, item := range val {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			if err := writeCanonical(buf, item); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+	case map[string]interface{}:
+		keys := make([]string, 0, len(val))
+		for k := range val {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		buf.WriteByte('{')
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			writePythonString(buf, k)
+			buf.WriteString(": ")
+			if err := writeCanonical(buf, val[k]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+	default:
+		return fmt.Errorf("canonical: unsupported type %T", v)
+	}
+	return nil
+}
+
+// writePythonString escapes a string the way Python's json.dumps does with
+// its default ensure_ascii=True.
+func writePythonString(buf *bytes.Buffer, s string) {
+	buf.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			buf.WriteString(`\"`)
+		case '\\':
+			buf.WriteString(`\\`)
+		case '\b':
+			buf.WriteString(`\b`)
+		case '\t':
+			buf.WriteString(`\t`)
+		case '\n':
+			buf.WriteString(`\n`)
+		case '\f':
+			buf.WriteString(`\f`)
+		case '\r':
+			buf.WriteString(`\r`)
+		default:
+			switch {
+			case r < 0x20:
+				fmt.Fprintf(buf, `\u%04x`, r)
+			case r < 0x7f:
+				buf.WriteRune(r)
+			case r > 0xFFFF:
+				hi, lo := utf16.EncodeRune(r)
+				fmt.Fprintf(buf, `\u%04x\u%04x`, hi, lo)
+			default:
+				fmt.Fprintf(buf, `\u%04x`, r)
+			}
+		}
+	}
+	buf.WriteByte('"')
+}

--- a/pkg/recorder/canonical_test.go
+++ b/pkg/recorder/canonical_test.go
@@ -1,0 +1,57 @@
+package recorder
+
+import "testing"
+
+// Golden outputs generated with:
+//
+//	python3 -c 'import json; print(json.dumps(json.loads(SRC), sort_keys=True))'
+//
+// If canonicalPythonJSON drifts from Python's serialization, chain hashes stop
+// verifying in the Python SDK, so these must match byte-for-byte.
+func TestCanonicalPythonJSONGoldens(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"sorted keys", `{"b":"x","a":1}`, `{"a": 1, "b": "x"}`},
+		{"nested sort", `{"tokens":{"prompt":64,"completion":48,"total":112},"model":"gpt-4"}`,
+			`{"model": "gpt-4", "tokens": {"completion": 48, "prompt": 64, "total": 112}}`},
+		{"short escapes", `{"s":"quote \" backslash \\ slash / tab \t newline \n"}`,
+			`{"s": "quote \" backslash \\ slash / tab \t newline \n"}`},
+		{"non-ascii", "{\"unicode\":\"héllo wörld\"}", `{"unicode": "h\u00e9llo w\u00f6rld"}`},
+		{"astral surrogate pair", "{\"emoji\":\"😀 ok\"}", `{"emoji": "\ud83d\ude00 ok"}`},
+		{"control chars", `{"ctrl":"\u0001\u001f"}`, `{"ctrl": "\u0001\u001f"}`},
+		{"del char", `{"d":"\u007f"}`, `{"d": "\u007f"}`},
+		{"nested mixed", `{"nested":{"z":[1,2,{"y":null,"t":true,"f":false}],"a":""}}`,
+			`{"nested": {"a": "", "z": [1, 2, {"f": false, "t": true, "y": null}]}}`},
+		{"numbers incl big int", `{"num":0,"neg":-5,"big":9007199254740993,"flt":0.5}`,
+			`{"big": 9007199254740993, "flt": 0.5, "neg": -5, "num": 0}`},
+		{"empties", `{"empty_obj":{},"empty_arr":[]}`, `{"empty_arr": [], "empty_obj": {}}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := canonicalPythonJSON([]byte(tc.in))
+			if err != nil {
+				t.Fatalf("canonicalPythonJSON: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalPythonJSONRealRecord(t *testing.T) {
+	// A realistic AIR record as the gateway marshals it.
+	in := `{"version":"1.0.0","run_id":"384def2a-3aa2-4300-82d2-9b12ea69cb42","trace_id":"","timestamp":"2026-07-03T01:24:20.707732101Z","model":"gpt-4","provider":"openai","endpoint":"/v1/chat/completions","request_vault_ref":"","response_vault_ref":"","request_checksum":"","response_checksum":"","tokens":{"prompt":64,"completion":48,"total":112},"duration_ms":2,"status":"success","chain_seq":1}`
+	want := `{"chain_seq": 1, "duration_ms": 2, "endpoint": "/v1/chat/completions", "model": "gpt-4", "provider": "openai", "request_checksum": "", "request_vault_ref": "", "response_checksum": "", "response_vault_ref": "", "run_id": "384def2a-3aa2-4300-82d2-9b12ea69cb42", "status": "success", "timestamp": "2026-07-03T01:24:20.707732101Z", "tokens": {"completion": 48, "prompt": 64, "total": 112}, "trace_id": "", "version": "1.0.0"}`
+	got, err := canonicalPythonJSON([]byte(in))
+	if err != nil {
+		t.Fatalf("canonicalPythonJSON: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("mismatch\n got: %s\nwant: %s", got, want)
+	}
+}

--- a/pkg/recorder/chain.go
+++ b/pkg/recorder/chain.go
@@ -1,0 +1,144 @@
+package recorder
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+)
+
+// genesisPrev seeds the chain, matching the Python SDK's
+// trust.chain.AuditChain.GENESIS.
+const genesisPrev = "genesis"
+
+// EnableChaining turns on tamper-evident chaining for this writer. Every
+// record written afterwards gets a chain_seq and a chain_hash computed as
+//
+//	HMAC-SHA256(key, prev_digest || canonical_json(record_without_chain_hash))
+//
+// which is the exact construction the Python SDK's trust layer writes and its
+// replay/evidence verifiers check. If the runs directory already contains
+// chained records, the chain resumes from the highest chain_seq so a gateway
+// restart does not reset the chain.
+//
+// It returns the sequence number the chain resumed at (0 for a fresh chain).
+func (w *Writer) EnableChaining(key string) (int64, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.key = []byte(key)
+	w.prev = []byte(genesisPrev)
+	w.seq = 0
+	if err := w.resumeLocked(); err != nil {
+		return 0, err
+	}
+	return w.seq, nil
+}
+
+// resumeLocked walks existing chained records in chain_seq order and advances
+// the writer's prev digest and sequence past them. It mirrors the Python
+// verifier: the expected digest advances at every chained record, so a
+// tampered historical record is still detectable by verification tools while
+// new records continue the canonical chain.
+func (w *Writer) resumeLocked() error {
+	paths, err := filepath.Glob(filepath.Join(w.dir, "*.air.json"))
+	if err != nil {
+		return err
+	}
+
+	type chained struct {
+		seq   int64
+		clean []byte
+	}
+	var recs []chained
+
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.UseNumber()
+		var m map[string]interface{}
+		if err := dec.Decode(&m); err != nil {
+			continue
+		}
+		seqNum, ok := m["chain_seq"].(json.Number)
+		if !ok {
+			continue // unchained record: not part of the chain
+		}
+		seq, err := seqNum.Int64()
+		if err != nil {
+			continue
+		}
+		delete(m, "chain_hash")
+		clean, err := canonicalValue(m)
+		if err != nil {
+			continue
+		}
+		recs = append(recs, chained{seq: seq, clean: clean})
+	}
+
+	sort.Slice(recs, func(i, j int) bool { return recs[i].seq < recs[j].seq })
+
+	for _, rec := range recs {
+		mac := hmac.New(sha256.New, w.key)
+		mac.Write(w.prev)
+		mac.Write(rec.clean)
+		w.prev = mac.Sum(nil)
+		w.seq = rec.seq
+	}
+	return nil
+}
+
+// writeChained persists a record with chain_seq and chain_hash. Must only be
+// called when chaining is enabled.
+func (w *Writer) writeChained(r Record) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	structJSON, err := json.Marshal(r)
+	if err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(structJSON))
+	dec.UseNumber()
+	var m map[string]interface{}
+	if err := dec.Decode(&m); err != nil {
+		return err
+	}
+
+	// The hash covers everything except chain_hash itself, chain_seq included.
+	delete(m, "chain_hash")
+	m["chain_seq"] = json.Number(strconv.FormatInt(w.seq+1, 10))
+
+	clean, err := canonicalValue(m)
+	if err != nil {
+		return err
+	}
+	mac := hmac.New(sha256.New, w.key)
+	mac.Write(w.prev)
+	mac.Write(clean)
+	sum := mac.Sum(nil)
+	m["chain_hash"] = hex.EncodeToString(sum)
+
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(w.dir, r.RunID+".air.json")
+	if err := os.WriteFile(path, out, 0644); err != nil {
+		return err
+	}
+
+	// Advance chain state only after a successful write, mirroring the
+	// Python writer.
+	w.seq++
+	w.prev = sum
+	return nil
+}

--- a/pkg/recorder/chain_test.go
+++ b/pkg/recorder/chain_test.go
@@ -1,0 +1,193 @@
+package recorder
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func chainedRecord(i int) Record {
+	return Record{
+		RunID:     "00000000-0000-0000-0000-00000000000" + string(rune('0'+i)),
+		Timestamp: time.Date(2026, 7, 3, 0, 0, i, 0, time.UTC),
+		Model:     "gpt-4",
+		Provider:  "openai",
+		Endpoint:  "/v1/chat/completions",
+		Tokens:    Tokens{Prompt: 5, Completion: 5, Total: 10},
+		Status:    "success",
+	}
+}
+
+// verifyLikePython recomputes the chain exactly as the Python SDK's
+// ReplayEngine.verify_chain does and reports the first break.
+func verifyLikePython(t *testing.T, dir, key string) (bool, int) {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(dir, "*.air.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type rec struct {
+		seq    int64
+		clean  []byte
+		stored string
+	}
+	var recs []rec
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dec := json.NewDecoder(bytes.NewReader(data))
+		dec.UseNumber()
+		var m map[string]interface{}
+		if err := dec.Decode(&m); err != nil {
+			t.Fatal(err)
+		}
+		seqNum, ok := m["chain_seq"].(json.Number)
+		if !ok {
+			continue
+		}
+		seq, _ := seqNum.Int64()
+		stored, _ := m["chain_hash"].(string)
+		delete(m, "chain_hash")
+		clean, err := canonicalValue(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		recs = append(recs, rec{seq: seq, clean: clean, stored: stored})
+	}
+	for i := range recs {
+		for j := i + 1; j < len(recs); j++ {
+			if recs[j].seq < recs[i].seq {
+				recs[i], recs[j] = recs[j], recs[i]
+			}
+		}
+	}
+
+	prev := []byte(genesisPrev)
+	for i, r := range recs {
+		mac := hmac.New(sha256.New, []byte(key))
+		mac.Write(prev)
+		mac.Write(r.clean)
+		sum := mac.Sum(nil)
+		if r.stored != hex.EncodeToString(sum) {
+			return false, i
+		}
+		prev = sum
+	}
+	return true, -1
+}
+
+func TestChainedWritesVerify(t *testing.T) {
+	dir := t.TempDir()
+	w, err := NewWriter(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.EnableChaining("test-key"); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := w.Write(chainedRecord(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ok, at := verifyLikePython(t, dir, "test-key")
+	if !ok {
+		t.Fatalf("untampered chain reported broken at %d", at)
+	}
+}
+
+func TestChainedWriteTamperDetected(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := NewWriter(dir)
+	if _, err := w.EnableChaining("test-key"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := w.Write(chainedRecord(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Tamper with the middle record.
+	path := filepath.Join(dir, chainedRecord(1).RunID+".air.json")
+	data, _ := os.ReadFile(path)
+	data = bytes.Replace(data, []byte(`"gpt-4"`), []byte(`"TAMPERED"`), 1)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, at := verifyLikePython(t, dir, "test-key")
+	if ok {
+		t.Fatal("tampered chain reported intact")
+	}
+	if at != 1 {
+		t.Fatalf("break reported at %d, want 1", at)
+	}
+}
+
+func TestChainResumesAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	w1, _ := NewWriter(dir)
+	if _, err := w1.EnableChaining("test-key"); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := w1.Write(chainedRecord(i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// "Restart": a fresh writer over the same directory must continue, not
+	// reset, the chain.
+	w2, _ := NewWriter(dir)
+	resumedAt, err := w2.EnableChaining("test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resumedAt != 2 {
+		t.Fatalf("resumed at %d, want 2", resumedAt)
+	}
+	if err := w2.Write(chainedRecord(2)); err != nil {
+		t.Fatal(err)
+	}
+
+	ok, at := verifyLikePython(t, dir, "test-key")
+	if !ok {
+		t.Fatalf("cross-restart chain reported broken at %d", at)
+	}
+
+	rec, err := Load(filepath.Join(dir, chainedRecord(2).RunID+".air.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.ChainSeq != 3 {
+		t.Fatalf("post-restart record has chain_seq %d, want 3", rec.ChainSeq)
+	}
+}
+
+func TestUnchainedWriterUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := NewWriter(dir)
+	if err := w.Write(chainedRecord(0)); err != nil {
+		t.Fatal(err)
+	}
+	rec, err := Load(filepath.Join(dir, chainedRecord(0).RunID+".air.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.ChainSeq != 0 || rec.ChainHash != "" {
+		t.Fatalf("unchained writer produced chain fields: seq=%d hash=%q", rec.ChainSeq, rec.ChainHash)
+	}
+}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -38,6 +38,11 @@ type Record struct {
 	// the same construction the Python SDK trust layer writes and verifies.
 	ChainSeq  int64  `json:"chain_seq,omitempty"`
 	ChainHash string `json:"chain_hash,omitempty"`
+	// Config attestation: hash of the agent's config bundle (prompts,
+	// skills, covenants) active for this call. Covered by chain_hash, so
+	// chained records bind each call to the exact configuration that
+	// produced it.
+	ConfigHash string `json:"config_hash,omitempty"`
 }
 
 // Tokens holds token usage from the provider response.

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -29,9 +30,14 @@ type Record struct {
 	Error            string    `json:"error,omitempty"`
 	// Trajectory linkage (additive, backward compatible). A lone call is a
 	// trajectory of one step. See docs/SPEC-trajectory-chain.md.
-	TrajectoryID     string    `json:"trajectory_id,omitempty"`
-	StepID           string    `json:"step_id,omitempty"`
-	ParentIDs        []string  `json:"parent_ids,omitempty"`
+	TrajectoryID string   `json:"trajectory_id,omitempty"`
+	StepID       string   `json:"step_id,omitempty"`
+	ParentIDs    []string `json:"parent_ids,omitempty"`
+	// Tamper-evidence (present when the writer has chaining enabled).
+	// chain_hash = HMAC-SHA256(key, prev_digest || canonical record JSON),
+	// the same construction the Python SDK trust layer writes and verifies.
+	ChainSeq  int64  `json:"chain_seq,omitempty"`
+	ChainHash string `json:"chain_hash,omitempty"`
 }
 
 // Tokens holds token usage from the provider response.
@@ -41,9 +47,16 @@ type Tokens struct {
 	Total      int `json:"total"`
 }
 
-// Writer writes AIR records to a directory.
+// Writer writes AIR records to a directory. With chaining enabled (see
+// EnableChaining) writes are serialized and each record is linked to the
+// previous one with an HMAC chain hash.
 type Writer struct {
 	dir string
+
+	mu   sync.Mutex
+	key  []byte // nil = chaining disabled
+	prev []byte
+	seq  int64
 }
 
 // NewWriter creates a writer that saves AIR files to dir.
@@ -57,6 +70,16 @@ func NewWriter(dir string) (*Writer, error) {
 // Write persists an AIR record as <run_id>.air.json.
 func (w *Writer) Write(r Record) error {
 	r.Version = "1.0.0"
+
+	if w.key != nil {
+		// Never trust caller-supplied chain fields; the writer owns them.
+		r.ChainSeq = 0
+		r.ChainHash = ""
+		if err := w.writeChained(r); err != nil {
+			return fmt.Errorf("recorder: write chained %s: %w", r.RunID, err)
+		}
+		return nil
+	}
 
 	data, err := json.MarshalIndent(r, "", "  ")
 	if err != nil {

--- a/pkg/trust/chain.go
+++ b/pkg/trust/chain.go
@@ -8,6 +8,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"sync"
 	"time"
 )
@@ -32,6 +34,7 @@ type AuditChain struct {
 	entries []ChainEntry
 	last    string // hash of last entry (for chaining)
 	seq     int64
+	file    *os.File // optional append-only persistence (see NewPersistentAuditChain)
 }
 
 // NewAuditChain creates a new audit chain with the given HMAC signing key.
@@ -71,6 +74,13 @@ func (ac *AuditChain) Append(runID string, recordJSON []byte) ChainEntry {
 	ac.last = sha256Hex(entryJSON)
 
 	ac.entries = append(ac.entries, entry)
+
+	// Best-effort write-through: persistence failures never block the chain.
+	if ac.file != nil {
+		if _, err := ac.file.Write(append(entryJSON, '\n')); err != nil {
+			log.Printf("trust: persist chain entry %d: %v", entry.Sequence, err)
+		}
+	}
 	return entry
 }
 

--- a/pkg/trust/keyfile.go
+++ b/pkg/trust/keyfile.go
@@ -1,0 +1,43 @@
+package trust
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LoadOrGenerateKey returns the signing key stored at path, generating a new
+// 256-bit random key on first use. The key never leaves the local machine.
+// This replaces the old hardcoded fallback key: an operator who sets no key
+// still gets unforgeable signatures, at the cost of having to keep (or back
+// up) the generated keyfile.
+func LoadOrGenerateKey(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		key := strings.TrimSpace(string(data))
+		if key == "" {
+			return "", fmt.Errorf("trust: keyfile %s is empty", path)
+		}
+		return key, nil
+	}
+	if !os.IsNotExist(err) {
+		return "", fmt.Errorf("trust: read keyfile: %w", err)
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("trust: generate key: %w", err)
+	}
+	key := hex.EncodeToString(raw)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", fmt.Errorf("trust: create key dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(key+"\n"), 0600); err != nil {
+		return "", fmt.Errorf("trust: write keyfile: %w", err)
+	}
+	return key, nil
+}

--- a/pkg/trust/persist.go
+++ b/pkg/trust/persist.go
@@ -1,0 +1,49 @@
+package trust
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// NewPersistentAuditChain creates an audit chain backed by an append-only
+// JSONL file. Existing entries are loaded on startup so the chain survives
+// gateway restarts, and every Append is written through to disk best-effort.
+func NewPersistentAuditChain(secret, path string) (*AuditChain, error) {
+	ac := NewAuditChain(secret)
+
+	if f, err := os.Open(path); err == nil {
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var entry ChainEntry
+			if err := json.Unmarshal(line, &entry); err != nil {
+				f.Close()
+				return nil, fmt.Errorf("trust: corrupt chain file %s: %w", path, err)
+			}
+			ac.entries = append(ac.entries, entry)
+			ac.seq = entry.Sequence
+			// Recompute the running hash exactly as Append does.
+			entryJSON, _ := json.Marshal(entry)
+			ac.last = sha256Hex(entryJSON)
+		}
+		f.Close()
+		if err := scanner.Err(); err != nil {
+			return nil, fmt.Errorf("trust: read chain file: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("trust: open chain file: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("trust: open chain file for append: %w", err)
+	}
+	ac.file = f
+	return ac, nil
+}

--- a/pkg/trust/persist_test.go
+++ b/pkg/trust/persist_test.go
@@ -1,0 +1,59 @@
+package trust
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPersistentChainSurvivesRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit-chain.jsonl")
+
+	ac1, err := NewPersistentAuditChain("test-key", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac1.Append("run-1", []byte(`{"run_id":"run-1"}`))
+	ac1.Append("run-2", []byte(`{"run_id":"run-2"}`))
+
+	// "Restart": reload from disk and keep appending.
+	ac2, err := NewPersistentAuditChain("test-key", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ac2.Len() != 2 {
+		t.Fatalf("reloaded chain has %d entries, want 2", ac2.Len())
+	}
+	ac2.Append("run-3", []byte(`{"run_id":"run-3"}`))
+
+	valid, brokenAt, err := ac2.Verify()
+	if !valid {
+		t.Fatalf("cross-restart chain invalid at %d: %v", brokenAt, err)
+	}
+
+	entries := ac2.Entries()
+	if len(entries) != 3 || entries[2].Sequence != 3 {
+		t.Fatalf("unexpected entries after restart: len=%d lastSeq=%d", len(entries), entries[len(entries)-1].Sequence)
+	}
+	if entries[2].PrevHash == "" {
+		t.Fatal("post-restart entry does not link to the loaded chain")
+	}
+}
+
+func TestLoadOrGenerateKeyRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".air-signing-key")
+
+	k1, err := LoadOrGenerateKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(k1) != 64 {
+		t.Fatalf("generated key has length %d, want 64 hex chars", len(k1))
+	}
+	k2, err := LoadOrGenerateKey(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k1 != k2 {
+		t.Fatal("second load did not return the persisted key")
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ adk = ["google-adk>=0.1.0"]
 claude = ["claude-agent-sdk>=0.1.0"]
 pdf = ["reportlab>=4.0"]
 gate = ["cryptography>=42.0"]
+lake = ["pyarrow>=14.0"]  # Parquet lake sink + in-lake chain verification
 pqc = ["oqs>=0.10.0"]  # post-quantum ML-DSA-65 signing (opt-in)
 all = [
     "air-blackbox[langchain]",
@@ -58,6 +59,7 @@ all = [
     "air-blackbox[claude]",
     "air-blackbox[pdf]",
     "air-blackbox[gate]",
+    "air-blackbox[lake]",
     "air-blackbox[pqc]",
 ]
 

--- a/sdk/air_blackbox/attest/__init__.py
+++ b/sdk/air_blackbox/attest/__init__.py
@@ -1,0 +1,21 @@
+"""Config-bundle attestation - bind every LLM call to the exact configuration
+that produced it.
+
+Prompts, skills, subagent definitions, and covenants are the source code of
+an agentic system. This module hashes that bundle into a deterministic
+manifest; the gateway stamps the resulting config_hash into every AIR record
+(AIR_CONFIG_HASH env or X-Air-Config-Hash header), and because the audit
+chain covers all record fields, the binding is tamper-evident for free.
+
+Incident flow: record -> config_hash -> manifest -> the exact file (by its
+own hash) that changed.
+"""
+
+from air_blackbox.attest.manifest import (
+    build_manifest,
+    check_manifest,
+    load_manifest,
+    save_manifest,
+)
+
+__all__ = ["build_manifest", "check_manifest", "load_manifest", "save_manifest"]

--- a/sdk/air_blackbox/attest/manifest.py
+++ b/sdk/air_blackbox/attest/manifest.py
@@ -1,0 +1,86 @@
+"""Deterministic config-bundle manifests.
+
+A manifest lists every file in the bundle with its SHA-256, sorted by
+relative path; config_hash is the SHA-256 of the canonical JSON of that
+list. Two bundles with identical contents produce identical hashes on any
+machine, regardless of argument order or filesystem iteration order.
+"""
+
+import hashlib
+import json
+import os
+from typing import Iterable, Optional
+
+# Files that are never part of an agent's behavior-defining config.
+_SKIP_NAMES = {".air-signing-key", ".DS_Store"}
+_SKIP_DIRS = {".git", "__pycache__", "node_modules", ".venv"}
+
+
+def _iter_files(path: str):
+    if os.path.isfile(path):
+        yield path
+        return
+    for root, dirs, files in os.walk(path):
+        dirs[:] = sorted(d for d in dirs if d not in _SKIP_DIRS)
+        for name in sorted(files):
+            if name not in _SKIP_NAMES:
+                yield os.path.join(root, name)
+
+
+def _sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def build_manifest(paths: Iterable[str], base_dir: Optional[str] = None) -> dict:
+    """Hash a config bundle. Paths may be files or directories; entries are
+    keyed by path relative to base_dir (default: current directory)."""
+    base = os.path.abspath(base_dir or ".")
+    files = {}
+    for p in paths:
+        for fpath in _iter_files(os.path.abspath(p)):
+            rel = os.path.relpath(fpath, base)
+            files[rel] = _sha256_file(fpath)
+
+    entries = [{"path": p, "sha256": files[p]} for p in sorted(files)]
+    canonical = json.dumps(entries, sort_keys=True).encode()
+    return {
+        "version": "1.0.0",
+        "files": entries,
+        "config_hash": hashlib.sha256(canonical).hexdigest(),
+    }
+
+
+def save_manifest(manifest: dict, path: str) -> str:
+    with open(path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    return path
+
+
+def load_manifest(path: str) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+def check_manifest(manifest: dict, base_dir: Optional[str] = None) -> list:
+    """Re-hash the files a manifest covers and report drift.
+
+    Returns a list of {path, expected, actual} dicts - empty means the
+    bundle on disk is exactly what was attested. actual is None for files
+    that have been deleted.
+    """
+    base = os.path.abspath(base_dir or ".")
+    drift = []
+    for entry in manifest.get("files", []):
+        fpath = os.path.join(base, entry["path"])
+        try:
+            actual = _sha256_file(fpath)
+        except OSError:
+            actual = None
+        if actual != entry["sha256"]:
+            drift.append({"path": entry["path"],
+                          "expected": entry["sha256"], "actual": actual})
+    return drift

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -2199,5 +2199,66 @@ def lake_verify(lake_dir, runs_dir, signing_key):
     raise SystemExit(1)
 
 
+@main.command("sandbox-run", context_settings={"ignore_unknown_options": True})
+@click.argument("command", nargs=-1, required=True, type=click.UNPROCESSED)
+@click.option("--gateway-bin", envvar="AIR_GATEWAY_BIN", default=None,
+              help="Path to the AIR gateway binary (managed mode)")
+@click.option("--gateway-url", default=None, help="Existing gateway URL (external mode)")
+@click.option("--runs-dir", default=None, help="Runs dir of the external gateway")
+@click.option("--provider", default="https://api.openai.com", help="Upstream LLM provider")
+@click.option("--guardrails", default=None, help="Guardrails config for the managed gateway")
+@click.option("--output", "-o", default="./sandbox-session", help="Session output directory")
+@click.option("--timeout", default=600, help="Agent timeout in seconds")
+def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrails, output, timeout):
+    """Run an agent in a recorded compliance sandbox.
+
+    Provisions an isolated gateway, points the agent at it via
+    OPENAI_BASE_URL, records every LLM call into a tamper-evident chain,
+    and emits a PASS/FAIL graduation report plus a signed evidence bundle.
+
+    \b
+        air-blackbox sandbox-run --gateway-bin ./gateway -- python my_agent.py
+    """
+    import os
+    from air_blackbox.sandbox import SandboxSession
+
+    console.print("\n[bold blue]AIR Blackbox[/] - Compliance Sandbox\n")
+    os.makedirs(output, exist_ok=True)
+    try:
+        session = SandboxSession(
+            sandbox_dir=output, gateway_bin=gateway_bin,
+            gateway_url=gateway_url, runs_dir=runs_dir,
+            provider_url=provider, guardrails_config=guardrails)
+    except ValueError as e:
+        console.print(f"[red]{e}[/]\n")
+        raise SystemExit(2)
+
+    console.print(f"  Agent: [bold]{' '.join(command)}[/]")
+    with console.status("[bold green]Running agent in sandbox..."):
+        verdict = session.run(list(command), timeout=timeout)
+
+    color = "green" if verdict.passed else "red"
+    lines = [
+        f"[bold {color}]{'PASS - agent graduates' if verdict.passed else 'FAIL - agent does not graduate'}[/]",
+        "",
+        f"  LLM calls recorded: {verdict.total_calls} ({verdict.error_calls} errored)",
+        f"  Chain: {'INTACT, ' + str(verdict.chain_verified) + ' verified' if verdict.chain_intact else 'BROKEN'}",
+        f"  Models: {', '.join(verdict.models) or 'none'}",
+        f"  Tokens: {verdict.total_tokens:,}  Duration: {verdict.duration_seconds}s",
+    ]
+    for reason in verdict.reasons:
+        lines.append(f"  [red]- {reason}[/]")
+    lines.append("")
+    lines.append(f"  Report: {verdict.sandbox_dir}/report.json")
+    if verdict.evidence_path:
+        lines.append(f"  Evidence bundle: {verdict.evidence_path}")
+    if verdict.lake_dir:
+        lines.append(f"  Lake dataset: {verdict.lake_dir}")
+    console.print(Panel("\n".join(lines), border_style=color))
+    console.print()
+    if not verdict.passed:
+        raise SystemExit(1)
+
+
 if __name__ == "__main__":
     main()

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -2209,7 +2209,9 @@ def lake_verify(lake_dir, runs_dir, signing_key):
 @click.option("--guardrails", default=None, help="Guardrails config for the managed gateway")
 @click.option("--output", "-o", default="./sandbox-session", help="Session output directory")
 @click.option("--timeout", default=600, help="Agent timeout in seconds")
-def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrails, output, timeout):
+@click.option("--config", "config_paths", multiple=True,
+              help="Attest these config files/dirs and bind every record to their hash")
+def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrails, output, timeout, config_paths):
     """Run an agent in a recorded compliance sandbox.
 
     Provisions an isolated gateway, points the agent at it via
@@ -2228,7 +2230,8 @@ def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrail
         session = SandboxSession(
             sandbox_dir=output, gateway_bin=gateway_bin,
             gateway_url=gateway_url, runs_dir=runs_dir,
-            provider_url=provider, guardrails_config=guardrails)
+            provider_url=provider, guardrails_config=guardrails,
+            config_paths=list(config_paths) or None)
     except ValueError as e:
         console.print(f"[red]{e}[/]\n")
         raise SystemExit(2)
@@ -2246,6 +2249,8 @@ def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrail
         f"  Models: {', '.join(verdict.models) or 'none'}",
         f"  Tokens: {verdict.total_tokens:,}  Duration: {verdict.duration_seconds}s",
     ]
+    if verdict.config_hash:
+        lines.append(f"  Config attested: {verdict.config_hash[:16]}... (bound into every record)")
     for reason in verdict.reasons:
         lines.append(f"  [red]- {reason}[/]")
     lines.append("")
@@ -2258,6 +2263,56 @@ def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrail
     console.print()
     if not verdict.passed:
         raise SystemExit(1)
+
+
+@main.group()
+def attest():
+    """Attest agent config bundles (prompts, skills, covenants).
+
+    \b
+        air-blackbox attest create prompts/ skills/ -o config-manifest.json
+        air-blackbox attest check -m config-manifest.json
+
+    Set the resulting hash as AIR_CONFIG_HASH on the gateway (or send the
+    X-Air-Config-Hash header per request) and every AIR record binds to the
+    exact configuration that produced it - tamper-evident via the chain.
+    """
+    pass
+
+
+@attest.command("create")
+@click.argument("paths", nargs=-1, required=True)
+@click.option("--output", "-o", default="config-manifest.json", help="Manifest output path")
+def attest_create(paths, output):
+    """Hash a config bundle into a deterministic manifest."""
+    from air_blackbox.attest import build_manifest, save_manifest
+
+    manifest = build_manifest(list(paths))
+    save_manifest(manifest, output)
+    console.print(f"\n[bold blue]AIR Blackbox[/] - Config Attestation\n")
+    console.print(f"  Files attested: {len(manifest['files'])}")
+    console.print(f"  config_hash: [bold]{manifest['config_hash']}[/]")
+    console.print(f"  Manifest: {output}\n")
+    console.print(f"  Bind it: export AIR_CONFIG_HASH={manifest['config_hash']}\n")
+
+
+@attest.command("check")
+@click.option("--manifest", "-m", default="config-manifest.json", help="Manifest to check against")
+def attest_check(manifest):
+    """Re-hash the attested files and report drift. Exits 1 on drift."""
+    from air_blackbox.attest import check_manifest, load_manifest
+
+    m = load_manifest(manifest)
+    drift = check_manifest(m)
+    console.print(f"\n[bold blue]AIR Blackbox[/] - Config Check\n")
+    if not drift:
+        console.print(f"  [green]✅ UNCHANGED[/] - all {len(m['files'])} files match the manifest ({m['config_hash'][:16]}...).\n")
+        return
+    for d in drift[:10]:
+        state = "deleted" if d["actual"] is None else "modified"
+        console.print(f"  [red]❌ {state}:[/] {d['path']}")
+    console.print(f"\n  [red]{len(drift)} file(s) drifted from the attested bundle.[/]\n")
+    raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -671,6 +671,8 @@ def discover(gateway, runs_dir, approved, fmt, output, init_registry):
 @click.option("--verify", is_flag=True, help="Verify HMAC audit chain")
 def replay(gateway, runs_dir, episode, last, verify):
     """Reconstruct AI incidents from the audit chain."""
+    import os
+
     from air_blackbox.replay.engine import ReplayEngine
 
     console.print("\n[bold blue]AIR Blackbox[/] - Incident Replay\n")
@@ -686,6 +688,10 @@ def replay(gateway, runs_dir, episode, last, verify):
     # Verify chain if requested
     if verify:
         console.print("[bold]Verifying HMAC audit chain...[/]\n")
+        _keyfile = os.path.join(runs_dir or "./runs", ".air-signing-key")
+        if not os.environ.get("TRUST_SIGNING_KEY") and not os.path.isfile(_keyfile):
+            console.print("  [dim]TRUST_SIGNING_KEY not set and no .air-signing-key found - verifying with the built-in default key.[/]")
+            console.print("  [dim]If the chain was signed with your own key, set TRUST_SIGNING_KEY first.[/]\n")
         result = engine.verify_chain()
         if result.intact and result.records_with_hash == 0:
             console.print(f"  [yellow]⚠  NO CHAIN HASHES[/] - {result.total_records:,} records loaded, but none carry a chain_hash.")

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -985,9 +985,6 @@ def demo(output):
         pass
 
 
-if __name__ == "__main__":
-    main()
-
 
 @main.command()
 @click.option("--output", "-o", default=".", help="Directory to initialize")
@@ -2110,3 +2107,97 @@ def retrain_all(canonical, min_count):
         console.print(f"  [red]Publish failed:[/] {pub_result.error}")
 
     console.print()
+
+
+@main.group()
+def lake():
+    """Land audit records in an open lakehouse table and verify them there.
+
+    Exports the gateway's chained .air.json records into a date-partitioned
+    Parquet dataset so agent audit data lives next to business data
+    (Databricks, Iceberg/Delta catalogs, DuckDB) and stays tamper-evident:
+    chain verification runs directly over the table.
+
+    Requires: pip install air-blackbox[lake]
+
+    Subcommands:
+
+        air-blackbox lake export    Export records to a Parquet dataset
+
+        air-blackbox lake verify    Verify the HMAC chain over the dataset
+    """
+    pass
+
+
+@lake.command("export")
+@click.option("--runs-dir", default="./runs", help="Directory of .air.json records")
+@click.option("--output", "-o", default="./air-lake", help="Lake dataset directory")
+@click.option("--full", is_flag=True, help="Re-export everything (default: only new records)")
+def lake_export(runs_dir, output, full):
+    """Export .air.json records into a partitioned Parquet dataset."""
+    try:
+        from air_blackbox.lake import export_records
+        import pyarrow  # noqa: F401
+    except ImportError:
+        console.print("[red]pyarrow is required:[/] pip install air-blackbox[lake]\n")
+        raise SystemExit(1)
+
+    console.print("\n[bold blue]AIR Blackbox[/] - Lake Export\n")
+    with console.status("[bold green]Exporting records..."):
+        count = export_records(runs_dir, output, incremental=not full)
+
+    if count == 0:
+        console.print("[yellow]No new records to export.[/]\n")
+        return
+
+    console.print(Panel(
+        f"[bold green]Export Complete[/]\n\n"
+        f"  Records written: {count}\n"
+        f"  Dataset: {output} (Parquet, hive-partitioned by date)\n\n"
+        f"  Query it with Spark, DuckDB, or any Parquet reader.\n"
+        f"  Verify it: air-blackbox lake verify -o {output}",
+        border_style="green",
+    ))
+    console.print()
+
+
+@lake.command("verify")
+@click.option("--output", "-o", "lake_dir", default="./air-lake", help="Lake dataset directory")
+@click.option("--runs-dir", default="./runs", help="Used to find the gateway's .air-signing-key")
+@click.option("--signing-key", default=None, help="Explicit HMAC signing key")
+def lake_verify(lake_dir, runs_dir, signing_key):
+    """Verify the HMAC audit chain directly over the Parquet dataset."""
+    try:
+        from air_blackbox.lake import verify_lake
+        import pyarrow  # noqa: F401
+    except ImportError:
+        console.print("[red]pyarrow is required:[/] pip install air-blackbox[lake]\n")
+        raise SystemExit(1)
+
+    console.print("\n[bold blue]AIR Blackbox[/] - Lake Verify\n")
+    with console.status("[bold green]Verifying chain over the table..."):
+        result = verify_lake(lake_dir, signing_key=signing_key, runs_dir=runs_dir)
+
+    chain = result.chain
+    if result.intact and chain.records_with_hash == 0:
+        console.print(f"  [yellow]⚠  NO CHAIN HASHES[/] - {chain.total_records:,} rows loaded, but none carry a chain_hash.")
+        console.print("  [yellow]  Records written without chaining cannot be verified for tampering.[/]\n")
+        return
+
+    if result.intact:
+        console.print(f"  [green]✅ CHAIN INTACT[/] - {chain.verified_records:,} records verified in the lake. No tampering detected.\n")
+        return
+
+    if not chain.intact:
+        console.print(f"  [red]❌ CHAIN BROKEN[/] at record {chain.first_break_at} (run: {chain.first_break_run_id})")
+        console.print(f"  [red]  {chain.verified_records} of {chain.total_records} records verified before break.[/]")
+    for m in result.column_mismatches[:10]:
+        console.print(f"  [red]❌ COLUMN MISMATCH[/] run {m['run_id']}: {m['column']} = {m['column_value']!r}, record says {m['record_value']!r}")
+    if len(result.column_mismatches) > 10:
+        console.print(f"  [red]  ...and {len(result.column_mismatches) - 10} more mismatches[/]")
+    console.print()
+    raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -687,7 +687,10 @@ def replay(gateway, runs_dir, episode, last, verify):
     if verify:
         console.print("[bold]Verifying HMAC audit chain...[/]\n")
         result = engine.verify_chain()
-        if result.intact:
+        if result.intact and result.records_with_hash == 0:
+            console.print(f"  [yellow]⚠  NO CHAIN HASHES[/] - {result.total_records:,} records loaded, but none carry a chain_hash.")
+            console.print("  [yellow]  Records written without a trust layer cannot be verified for tampering.[/]\n")
+        elif result.intact:
             console.print(f"  [green]✅ CHAIN INTACT[/] - {result.verified_records:,} records verified. No tampering detected.\n")
         else:
             console.print(f"  [red]❌ CHAIN BROKEN[/] at record {result.first_break_at} (run: {result.first_break_run_id})")

--- a/sdk/air_blackbox/injection/detector.py
+++ b/sdk/air_blackbox/injection/detector.py
@@ -160,6 +160,7 @@ INJECTION_PATTERNS: list[PatternDef] = [
         name="safety_bypass",
         regex=re.compile(
             r"(?:bypass|disable|turn\s+off|remove|override)\s+"
+            r"(?:(?:the|your|all|any|this|these|those|its|content|output|safety)\s+){0,2}"
             r"(?:safety|filter|guard|restriction|limit|protection"
             r"|moderation|censorship|content\s+policy)",
             re.IGNORECASE,
@@ -186,7 +187,7 @@ INJECTION_PATTERNS: list[PatternDef] = [
         name="data_exfil",
         regex=re.compile(
             r"(?:send|transmit|forward|email|post|upload)\s+"
-            r"(?:all|the|my|this|your)\s+"
+            r"(?:(?:all|the|my|this|your|our|of)\s+){1,3}"
             r"(?:data|information|content|conversation|history"
             r"|context|system\s+prompt|instructions|secrets|keys)",
             re.IGNORECASE,

--- a/sdk/air_blackbox/lake/__init__.py
+++ b/sdk/air_blackbox/lake/__init__.py
@@ -1,0 +1,19 @@
+"""AIR on the lakehouse - land audit records as open-format tables.
+
+The lake sink exports the gateway's chained .air.json records into a
+date-partitioned Parquet dataset so agent audit data can live next to
+business data in a lakehouse (Databricks, Iceberg/Delta catalogs, DuckDB,
+plain object storage) and be queried with SQL.
+
+Tamper-evidence survives the move: each row carries the record's exact
+JSON (`record_json`) plus flattened columns for querying, and
+`verify_lake` re-runs the same HMAC chain verification the replay engine
+uses - directly over the table. The signing key never enters the lake.
+
+Requires the optional dependency: pip install air-blackbox[lake]
+"""
+
+from air_blackbox.lake.writer import export_records
+from air_blackbox.lake.verify import LakeVerification, verify_lake
+
+__all__ = ["export_records", "verify_lake", "LakeVerification"]

--- a/sdk/air_blackbox/lake/verify.py
+++ b/sdk/air_blackbox/lake/verify.py
@@ -58,6 +58,8 @@ def _resolve_key(signing_key: Optional[str], runs_dir: Optional[str]) -> bytes:
                 if key:
                     return key.encode()
         except OSError:
+            # The keyfile is an optional convenience source; fall through
+            # to the development default when it doesn't exist.
             pass
     return b"air-blackbox-default"
 

--- a/sdk/air_blackbox/lake/verify.py
+++ b/sdk/air_blackbox/lake/verify.py
@@ -1,0 +1,108 @@
+"""Chain verification directly over the Parquet dataset.
+
+Two layers of checking:
+
+1. Chain integrity: the record_json column carries each record exactly as
+   recorded; the rows are ordered by (chain_seq, timestamp) and run through
+   the same HMAC-SHA256 chain walk the replay engine uses. Tampering with
+   any record breaks every record after it.
+2. Column consistency: the flattened SQL columns must agree with
+   record_json, so an attacker cannot present clean analytics columns while
+   the verified payload says otherwise (or vice versa).
+
+The equivalent walk runs anywhere the table does - a Spark UDF, a DuckDB
+query, a notebook - because verification needs only the rows and the key.
+"""
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+from air_blackbox.replay.engine import ChainVerification, verify_records
+
+# Flattened columns that must agree with the verified record_json payload.
+_CONSISTENCY_COLUMNS = (
+    ("run_id", "run_id"),
+    ("timestamp", "timestamp"),
+    ("model", "model"),
+    ("provider", "provider"),
+    ("endpoint", "endpoint"),
+    ("status", "status"),
+    ("chain_hash", "chain_hash"),
+)
+
+
+@dataclass
+class LakeVerification:
+    chain: ChainVerification
+    column_mismatches: list = field(default_factory=list)
+
+    @property
+    def intact(self) -> bool:
+        return self.chain.intact and not self.column_mismatches
+
+
+def _resolve_key(signing_key: Optional[str], runs_dir: Optional[str]) -> bytes:
+    """Same resolution order as the replay engine: explicit key, env var,
+    the gateway's generated keyfile, then the development default."""
+    if signing_key:
+        return signing_key.encode()
+    env = os.environ.get("TRUST_SIGNING_KEY")
+    if env:
+        return env.encode()
+    if runs_dir:
+        try:
+            with open(os.path.join(runs_dir, ".air-signing-key")) as f:
+                key = f.read().strip()
+                if key:
+                    return key.encode()
+        except OSError:
+            pass
+    return b"air-blackbox-default"
+
+
+def verify_lake(lake_dir: str, signing_key: Optional[str] = None,
+                runs_dir: Optional[str] = None) -> LakeVerification:
+    """Verify the HMAC audit chain over a Parquet lake dataset."""
+    import pyarrow.dataset as ds
+
+    # The date column is stored in the files themselves, so hive partition
+    # inference is unnecessary (and its dictionary-typed column would clash
+    # with the string column when fragments are merged).
+    dataset = ds.dataset(lake_dir, format="parquet")
+    rows = dataset.to_table().to_pylist()
+    rows.sort(key=lambda r: (r.get("chain_seq") or 0, r.get("timestamp") or ""))
+
+    mismatches = []
+    records = []
+    for row in rows:
+        rec = json.loads(row["record_json"])
+        records.append(rec)
+        for col, json_field in _CONSISTENCY_COLUMNS:
+            if (row.get(col) or "") != (rec.get(json_field) or ""):
+                mismatches.append({
+                    "run_id": row.get("run_id"),
+                    "column": col,
+                    "column_value": row.get(col),
+                    "record_value": rec.get(json_field),
+                })
+        tokens = rec.get("tokens") or {}
+        if int(row.get("tokens_total") or 0) != int(tokens.get("total", 0) or 0):
+            mismatches.append({
+                "run_id": row.get("run_id"),
+                "column": "tokens_total",
+                "column_value": row.get("tokens_total"),
+                "record_value": tokens.get("total"),
+            })
+        if int(row.get("chain_seq") or 0) != int(rec.get("chain_seq", 0) or 0):
+            mismatches.append({
+                "run_id": row.get("run_id"),
+                "column": "chain_seq",
+                "column_value": row.get("chain_seq"),
+                "record_value": rec.get("chain_seq"),
+            })
+
+    key = _resolve_key(signing_key, runs_dir)
+    chain = verify_records(records, key)
+    return LakeVerification(chain=chain, column_mismatches=mismatches)

--- a/sdk/air_blackbox/lake/writer.py
+++ b/sdk/air_blackbox/lake/writer.py
@@ -1,0 +1,95 @@
+"""Export chained .air.json records into a partitioned Parquet dataset."""
+
+import glob
+import json
+import os
+
+
+def _schema():
+    import pyarrow as pa
+
+    return pa.schema([
+        ("run_id", pa.string()),
+        ("timestamp", pa.string()),   # exact RFC3339 string, never a converted type
+        ("date", pa.string()),        # hive partition key, derived from timestamp
+        ("model", pa.string()),
+        ("provider", pa.string()),
+        ("endpoint", pa.string()),
+        ("status", pa.string()),
+        ("tokens_prompt", pa.int64()),
+        ("tokens_completion", pa.int64()),
+        ("tokens_total", pa.int64()),
+        ("duration_ms", pa.int64()),
+        ("trace_id", pa.string()),
+        ("chain_seq", pa.int64()),
+        ("chain_hash", pa.string()),
+        # Source of truth: the record exactly as recorded, compact JSON.
+        # Verification and replay read this; the columns above exist for SQL.
+        ("record_json", pa.string()),
+    ])
+
+
+def _flatten(rec: dict) -> dict:
+    tokens = rec.get("tokens") or {}
+    timestamp = rec.get("timestamp", "")
+    return {
+        "run_id": rec.get("run_id", ""),
+        "timestamp": timestamp,
+        "date": timestamp[:10] if len(timestamp) >= 10 else "unknown",
+        "model": rec.get("model", ""),
+        "provider": rec.get("provider", ""),
+        "endpoint": rec.get("endpoint", ""),
+        "status": rec.get("status", ""),
+        "tokens_prompt": int(tokens.get("prompt", 0) or 0),
+        "tokens_completion": int(tokens.get("completion", 0) or 0),
+        "tokens_total": int(tokens.get("total", 0) or 0),
+        "duration_ms": int(rec.get("duration_ms", 0) or 0),
+        "trace_id": rec.get("trace_id", ""),
+        "chain_seq": int(rec.get("chain_seq", 0) or 0),
+        "chain_hash": rec.get("chain_hash", ""),
+        "record_json": json.dumps(rec, sort_keys=True),
+    }
+
+
+def _existing_run_ids(lake_dir: str) -> set:
+    import pyarrow.dataset as ds
+
+    has_parts = glob.glob(os.path.join(lake_dir, "**", "*.parquet"), recursive=True)
+    if not has_parts:
+        return set()
+    dataset = ds.dataset(lake_dir, format="parquet")
+    return set(dataset.to_table(columns=["run_id"])["run_id"].to_pylist())
+
+
+def export_records(runs_dir: str, lake_dir: str, incremental: bool = True) -> int:
+    """Export .air.json records from runs_dir into a Parquet dataset.
+
+    The dataset is hive-partitioned by date (date=YYYY-MM-DD/...). With
+    incremental=True (the default), run_ids already present in the dataset
+    are skipped, so repeated exports append only new records.
+
+    Returns the number of records written.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    skip = _existing_run_ids(lake_dir) if incremental else set()
+
+    rows = []
+    for path in sorted(glob.glob(os.path.join(runs_dir, "**", "*.air.json"),
+                                 recursive=True)):
+        try:
+            with open(path) as f:
+                rec = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        if rec.get("run_id") in skip:
+            continue
+        rows.append(_flatten(rec))
+
+    if not rows:
+        return 0
+
+    table = pa.Table.from_pylist(rows, schema=_schema())
+    pq.write_to_dataset(table, root_path=lake_dir, partition_cols=["date"])
+    return len(rows)

--- a/sdk/air_blackbox/replay/engine.py
+++ b/sdk/air_blackbox/replay/engine.py
@@ -42,6 +42,7 @@ class ChainVerification:
     verified_records: int
     first_break_at: Optional[int] = None
     first_break_run_id: Optional[str] = None
+    records_with_hash: int = 0
 
 
 class ReplayEngine:
@@ -117,27 +118,32 @@ class ReplayEngine:
         key = (signing_key or os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")).encode()
         prev_hash = b"genesis"
         verified = 0
+        with_hash = 0
 
         for i, raw in enumerate(self._raw_records):
-            record_bytes = json.dumps(raw, sort_keys=True).encode()
-            expected_hash = hmac.new(key, prev_hash + record_bytes, hashlib.sha256).digest()
+            # The chain hash is computed over the record as it existed before
+            # the hash was embedded, so it must be excluded here (this matches
+            # trust.chain.AuditChain.write and the evidence bundle verifier).
+            record_clean = {k: v for k, v in raw.items() if k != "chain_hash"}
+            record_bytes = json.dumps(record_clean, sort_keys=True).encode()
+            expected = hmac.new(key, prev_hash + record_bytes, hashlib.sha256)
 
-            # Check if record has a stored hash
             stored_hash = raw.get("chain_hash")
             if stored_hash:
-                if stored_hash != expected_hash.hex():
+                with_hash += 1
+                if stored_hash != expected.hexdigest():
                     return ChainVerification(
                         intact=False, total_records=len(self._raw_records),
                         verified_records=verified, first_break_at=i,
                         first_break_run_id=raw.get("run_id"),
+                        records_with_hash=with_hash,
                     )
-            # Even without stored hashes, we compute the chain
-            prev_hash = expected_hash
-            verified += 1
+                verified += 1
+            prev_hash = expected.digest()
 
         return ChainVerification(
             intact=True, total_records=len(self._raw_records),
-            verified_records=verified,
+            verified_records=verified, records_with_hash=with_hash,
         )
 
     def get_stats(self) -> dict:

--- a/sdk/air_blackbox/replay/engine.py
+++ b/sdk/air_blackbox/replay/engine.py
@@ -68,7 +68,11 @@ class ReplayEngine:
                     self._raw_records.append(rec)
             except (json.JSONDecodeError, IOError):
                 continue
-        self._raw_records.sort(key=lambda r: r.get("timestamp", ""))
+        # Chained records (chain_seq set, e.g. from the Go gateway) verify in
+        # append order; everything else falls back to timestamp order.
+        self._raw_records.sort(
+            key=lambda r: (r.get("chain_seq", 0), r.get("timestamp", ""))
+        )
         self.records = [self._parse(r) for r in self._raw_records]
         return len(self.records)
 
@@ -115,12 +119,19 @@ class ReplayEngine:
         Each record's hash should chain to the next. If any record
         is modified, the chain breaks from that point forward.
         """
-        key = (signing_key or os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")).encode()
+        key = (signing_key or os.environ.get("TRUST_SIGNING_KEY")
+               or self._runs_dir_key() or "air-blackbox-default").encode()
         prev_hash = b"genesis"
         verified = 0
         with_hash = 0
 
         for i, raw in enumerate(self._raw_records):
+            stored_hash = raw.get("chain_hash")
+            if not stored_hash:
+                # Unchained records (written before chaining was enabled)
+                # are outside the chain entirely.
+                continue
+
             # The chain hash is computed over the record as it existed before
             # the hash was embedded, so it must be excluded here (this matches
             # trust.chain.AuditChain.write and the evidence bundle verifier).
@@ -128,23 +139,31 @@ class ReplayEngine:
             record_bytes = json.dumps(record_clean, sort_keys=True).encode()
             expected = hmac.new(key, prev_hash + record_bytes, hashlib.sha256)
 
-            stored_hash = raw.get("chain_hash")
-            if stored_hash:
-                with_hash += 1
-                if stored_hash != expected.hexdigest():
-                    return ChainVerification(
-                        intact=False, total_records=len(self._raw_records),
-                        verified_records=verified, first_break_at=i,
-                        first_break_run_id=raw.get("run_id"),
-                        records_with_hash=with_hash,
-                    )
-                verified += 1
+            with_hash += 1
+            if stored_hash != expected.hexdigest():
+                return ChainVerification(
+                    intact=False, total_records=len(self._raw_records),
+                    verified_records=verified, first_break_at=i,
+                    first_break_run_id=raw.get("run_id"),
+                    records_with_hash=with_hash,
+                )
+            verified += 1
             prev_hash = expected.digest()
 
         return ChainVerification(
             intact=True, total_records=len(self._raw_records),
             verified_records=verified, records_with_hash=with_hash,
         )
+
+    def _runs_dir_key(self) -> Optional[str]:
+        """Read the signing key the gateway auto-generates alongside the
+        records (.air-signing-key), so verification works with zero config."""
+        try:
+            with open(os.path.join(self.runs_dir, ".air-signing-key")) as f:
+                key = f.read().strip()
+                return key or None
+        except OSError:
+            return None
 
     def get_stats(self) -> dict:
         """Get summary statistics for all records."""

--- a/sdk/air_blackbox/replay/engine.py
+++ b/sdk/air_blackbox/replay/engine.py
@@ -45,6 +45,50 @@ class ChainVerification:
     records_with_hash: int = 0
 
 
+def verify_records(records: list, key: bytes) -> ChainVerification:
+    """Verify a HMAC-SHA256 chain over ordered record dicts.
+
+    This is the single verification implementation shared by the replay
+    engine (records from .air.json files) and the lake verifier (records
+    from Parquet tables). Records must already be ordered by
+    (chain_seq, timestamp); records without a chain_hash are outside the
+    chain and never advance the digest.
+    """
+    prev_hash = b"genesis"
+    verified = 0
+    with_hash = 0
+
+    for i, raw in enumerate(records):
+        stored_hash = raw.get("chain_hash")
+        if not stored_hash:
+            # Unchained records (written before chaining was enabled)
+            # are outside the chain entirely.
+            continue
+
+        # The chain hash is computed over the record as it existed before
+        # the hash was embedded, so it must be excluded here (this matches
+        # trust.chain.AuditChain.write and the evidence bundle verifier).
+        record_clean = {k: v for k, v in raw.items() if k != "chain_hash"}
+        record_bytes = json.dumps(record_clean, sort_keys=True).encode()
+        expected = hmac.new(key, prev_hash + record_bytes, hashlib.sha256)
+
+        with_hash += 1
+        if stored_hash != expected.hexdigest():
+            return ChainVerification(
+                intact=False, total_records=len(records),
+                verified_records=verified, first_break_at=i,
+                first_break_run_id=raw.get("run_id"),
+                records_with_hash=with_hash,
+            )
+        verified += 1
+        prev_hash = expected.digest()
+
+    return ChainVerification(
+        intact=True, total_records=len(records),
+        verified_records=verified, records_with_hash=with_hash,
+    )
+
+
 class ReplayEngine:
     """Loads, filters, and replays .air.json audit records."""
 
@@ -121,39 +165,7 @@ class ReplayEngine:
         """
         key = (signing_key or os.environ.get("TRUST_SIGNING_KEY")
                or self._runs_dir_key() or "air-blackbox-default").encode()
-        prev_hash = b"genesis"
-        verified = 0
-        with_hash = 0
-
-        for i, raw in enumerate(self._raw_records):
-            stored_hash = raw.get("chain_hash")
-            if not stored_hash:
-                # Unchained records (written before chaining was enabled)
-                # are outside the chain entirely.
-                continue
-
-            # The chain hash is computed over the record as it existed before
-            # the hash was embedded, so it must be excluded here (this matches
-            # trust.chain.AuditChain.write and the evidence bundle verifier).
-            record_clean = {k: v for k, v in raw.items() if k != "chain_hash"}
-            record_bytes = json.dumps(record_clean, sort_keys=True).encode()
-            expected = hmac.new(key, prev_hash + record_bytes, hashlib.sha256)
-
-            with_hash += 1
-            if stored_hash != expected.hexdigest():
-                return ChainVerification(
-                    intact=False, total_records=len(self._raw_records),
-                    verified_records=verified, first_break_at=i,
-                    first_break_run_id=raw.get("run_id"),
-                    records_with_hash=with_hash,
-                )
-            verified += 1
-            prev_hash = expected.digest()
-
-        return ChainVerification(
-            intact=True, total_records=len(self._raw_records),
-            verified_records=verified, records_with_hash=with_hash,
-        )
+        return verify_records(self._raw_records, key)
 
     def _runs_dir_key(self) -> Optional[str]:
         """Read the signing key the gateway auto-generates alongside the

--- a/sdk/air_blackbox/sandbox/__init__.py
+++ b/sdk/air_blackbox/sandbox/__init__.py
@@ -1,0 +1,14 @@
+"""Compliance AI sandbox - agents graduate to production with a signed record.
+
+A sandbox session provisions an isolated AIR gateway (fresh runs directory,
+locally generated signing key), runs your agent against it, and produces a
+graduation report: was every LLM call recorded, is the chain intact, did
+anything error or get blocked. The exit artifact is a signed evidence bundle
+an approver can verify independently.
+
+    air-blackbox sandbox run --gateway-bin ./gateway -- python my_agent.py
+"""
+
+from air_blackbox.sandbox.session import SandboxSession, SandboxVerdict
+
+__all__ = ["SandboxSession", "SandboxVerdict"]

--- a/sdk/air_blackbox/sandbox/session.py
+++ b/sdk/air_blackbox/sandbox/session.py
@@ -41,6 +41,7 @@ class SandboxVerdict:
     sandbox_dir: str = ""
     evidence_path: Optional[str] = None
     lake_dir: Optional[str] = None
+    config_hash: Optional[str] = None
 
 
 def _free_port() -> int:
@@ -59,7 +60,8 @@ class SandboxSession:
                  gateway_url: Optional[str] = None,
                  runs_dir: Optional[str] = None,
                  provider_url: str = "https://api.openai.com",
-                 guardrails_config: Optional[str] = None):
+                 guardrails_config: Optional[str] = None,
+                 config_paths: Optional[list] = None):
         if not gateway_bin and not (gateway_url and runs_dir):
             raise ValueError(
                 "need gateway_bin (managed mode) or gateway_url + runs_dir "
@@ -70,6 +72,8 @@ class SandboxSession:
         self.runs_dir = runs_dir or os.path.join(self.sandbox_dir, "runs")
         self.provider_url = provider_url
         self.guardrails_config = guardrails_config
+        self.config_paths = config_paths or []
+        self._manifest = None
         self._gateway_proc = None
 
     # -- gateway lifecycle ------------------------------------------------
@@ -85,6 +89,8 @@ class SandboxSession:
         })
         if self.guardrails_config:
             env["GUARDRAILS_CONFIG"] = os.path.abspath(self.guardrails_config)
+        if self._manifest:
+            env["AIR_CONFIG_HASH"] = self._manifest["config_hash"]
         log = open(os.path.join(self.sandbox_dir, "gateway.log"), "w")
         self._gateway_proc = subprocess.Popen(
             [self.gateway_bin], env=env, stdout=log, stderr=subprocess.STDOUT)
@@ -122,6 +128,15 @@ class SandboxSession:
         os.makedirs(self.runs_dir, exist_ok=True)
         started = time.monotonic()
 
+        # Attest the agent's config bundle before it runs; the gateway
+        # stamps the hash into every record, binding each call to the
+        # exact prompts/skills/covenants that produced it.
+        if self.config_paths:
+            from air_blackbox.attest import build_manifest, save_manifest
+            self._manifest = build_manifest(self.config_paths)
+            save_manifest(self._manifest,
+                          os.path.join(self.sandbox_dir, "config-manifest.json"))
+
         url = self.gateway_url
         try:
             if self.gateway_bin:
@@ -134,6 +149,8 @@ class SandboxSession:
                 "AIR_GATEWAY_URL": url,
                 "AIR_SANDBOX": "1",
             })
+            if self._manifest:
+                env["AIR_CONFIG_HASH"] = self._manifest["config_hash"]
             with open(os.path.join(self.sandbox_dir, "agent.stdout"), "wb") as out, \
                  open(os.path.join(self.sandbox_dir, "agent.stderr"), "wb") as err:
                 try:
@@ -175,6 +192,15 @@ class SandboxSession:
         if errors:
             reasons.append(f"{errors} LLM call(s) errored")
 
+        config_hash = None
+        if self._manifest:
+            from air_blackbox.attest import check_manifest
+            config_hash = self._manifest["config_hash"]
+            drift = check_manifest(self._manifest)
+            if drift:
+                changed = ", ".join(d["path"] for d in drift[:5])
+                reasons.append(f"agent config changed during the run: {changed}")
+
         verdict = SandboxVerdict(
             passed=not reasons,
             reasons=reasons,
@@ -187,6 +213,7 @@ class SandboxSession:
             total_tokens=stats.get("total_tokens", 0),
             duration_seconds=round(duration, 2),
             sandbox_dir=self.sandbox_dir,
+            config_hash=config_hash,
         )
 
         verdict.lake_dir = self._export_lake()

--- a/sdk/air_blackbox/sandbox/session.py
+++ b/sdk/air_blackbox/sandbox/session.py
@@ -16,7 +16,6 @@ exited 0. The evidence bundle is generated with the same tooling as
 
 import json
 import os
-import shutil
 import socket
 import subprocess
 import time
@@ -75,6 +74,7 @@ class SandboxSession:
         self.config_paths = config_paths or []
         self._manifest = None
         self._gateway_proc = None
+        self._gateway_log = None
 
     # -- gateway lifecycle ------------------------------------------------
 
@@ -91,9 +91,10 @@ class SandboxSession:
             env["GUARDRAILS_CONFIG"] = os.path.abspath(self.guardrails_config)
         if self._manifest:
             env["AIR_CONFIG_HASH"] = self._manifest["config_hash"]
-        log = open(os.path.join(self.sandbox_dir, "gateway.log"), "w")
+        self._gateway_log = open(os.path.join(self.sandbox_dir, "gateway.log"), "w")
         self._gateway_proc = subprocess.Popen(
-            [self.gateway_bin], env=env, stdout=log, stderr=subprocess.STDOUT)
+            [self.gateway_bin], env=env,
+            stdout=self._gateway_log, stderr=subprocess.STDOUT)
         self._wait_healthy(url)
         return url
 
@@ -109,18 +110,25 @@ class SandboxSession:
                 if httpx.get(f"{url}/health", timeout=1.0).status_code == 200:
                     return
             except httpx.HTTPError:
+                # Expected while the gateway is still binding its port;
+                # keep polling until the deadline.
                 pass
             time.sleep(0.2)
         raise RuntimeError(f"gateway not healthy after {timeout}s")
 
     def _stop_gateway(self):
-        if self._gateway_proc and self._gateway_proc.poll() is None:
-            self._gateway_proc.terminate()
-            try:
-                self._gateway_proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                self._gateway_proc.kill()
-        self._gateway_proc = None
+        try:
+            if self._gateway_proc and self._gateway_proc.poll() is None:
+                self._gateway_proc.terminate()
+                try:
+                    self._gateway_proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    self._gateway_proc.kill()
+        finally:
+            self._gateway_proc = None
+            if self._gateway_log:
+                self._gateway_log.close()
+                self._gateway_log = None
 
     # -- the session ------------------------------------------------------
 
@@ -263,5 +271,7 @@ class SandboxSession:
                 if key:
                     return key
         except OSError:
+            # No generated keyfile (external-gateway mode, or recording was
+            # disabled); fall back to the env var / development default.
             pass
         return os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")

--- a/sdk/air_blackbox/sandbox/session.py
+++ b/sdk/air_blackbox/sandbox/session.py
@@ -1,0 +1,240 @@
+"""Sandbox session orchestration.
+
+Two modes:
+
+- Managed gateway: pass gateway_bin and the session spawns an isolated
+  gateway on a free port with its own runs directory and generated signing
+  key, points the agent at it via OPENAI_BASE_URL, and tears it down after.
+- External gateway: pass gateway_url + runs_dir for a gateway you already
+  run; the session only orchestrates the agent and the analysis.
+
+The verdict is computed from the recorded evidence, not the agent's word:
+chain intact, every call recorded and chained, zero errored calls, agent
+exited 0. The evidence bundle is generated with the same tooling as
+`air-blackbox export`, so approvers verify it the same way.
+"""
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+from air_blackbox.replay.engine import ReplayEngine
+
+
+@dataclass
+class SandboxVerdict:
+    passed: bool
+    reasons: list = field(default_factory=list)
+    agent_exit_code: int = 0
+    total_calls: int = 0
+    error_calls: int = 0
+    chain_intact: bool = False
+    chain_verified: int = 0
+    models: dict = field(default_factory=dict)
+    total_tokens: int = 0
+    duration_seconds: float = 0.0
+    sandbox_dir: str = ""
+    evidence_path: Optional[str] = None
+    lake_dir: Optional[str] = None
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class SandboxSession:
+    """One recorded, isolated run of an agent behind an AIR gateway."""
+
+    def __init__(self, sandbox_dir: str,
+                 gateway_bin: Optional[str] = None,
+                 gateway_url: Optional[str] = None,
+                 runs_dir: Optional[str] = None,
+                 provider_url: str = "https://api.openai.com",
+                 guardrails_config: Optional[str] = None):
+        if not gateway_bin and not (gateway_url and runs_dir):
+            raise ValueError(
+                "need gateway_bin (managed mode) or gateway_url + runs_dir "
+                "(external gateway mode)")
+        self.sandbox_dir = os.path.abspath(sandbox_dir)
+        self.gateway_bin = gateway_bin
+        self.gateway_url = gateway_url
+        self.runs_dir = runs_dir or os.path.join(self.sandbox_dir, "runs")
+        self.provider_url = provider_url
+        self.guardrails_config = guardrails_config
+        self._gateway_proc = None
+
+    # -- gateway lifecycle ------------------------------------------------
+
+    def _start_gateway(self) -> str:
+        port = _free_port()
+        url = f"http://127.0.0.1:{port}"
+        env = dict(os.environ)
+        env.update({
+            "LISTEN_ADDR": f"127.0.0.1:{port}",
+            "PROVIDER_URL": self.provider_url,
+            "RUNS_DIR": self.runs_dir,
+        })
+        if self.guardrails_config:
+            env["GUARDRAILS_CONFIG"] = os.path.abspath(self.guardrails_config)
+        log = open(os.path.join(self.sandbox_dir, "gateway.log"), "w")
+        self._gateway_proc = subprocess.Popen(
+            [self.gateway_bin], env=env, stdout=log, stderr=subprocess.STDOUT)
+        self._wait_healthy(url)
+        return url
+
+    def _wait_healthy(self, url: str, timeout: float = 10.0):
+        import httpx
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._gateway_proc and self._gateway_proc.poll() is not None:
+                raise RuntimeError(
+                    f"gateway exited early (code {self._gateway_proc.returncode}); "
+                    f"see {self.sandbox_dir}/gateway.log")
+            try:
+                if httpx.get(f"{url}/health", timeout=1.0).status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+            time.sleep(0.2)
+        raise RuntimeError(f"gateway not healthy after {timeout}s")
+
+    def _stop_gateway(self):
+        if self._gateway_proc and self._gateway_proc.poll() is None:
+            self._gateway_proc.terminate()
+            try:
+                self._gateway_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._gateway_proc.kill()
+        self._gateway_proc = None
+
+    # -- the session ------------------------------------------------------
+
+    def run(self, command: list, timeout: int = 600) -> SandboxVerdict:
+        os.makedirs(self.runs_dir, exist_ok=True)
+        started = time.monotonic()
+
+        url = self.gateway_url
+        try:
+            if self.gateway_bin:
+                url = self._start_gateway()
+
+            env = dict(os.environ)
+            env.update({
+                "OPENAI_BASE_URL": f"{url}/v1",
+                "OPENAI_API_BASE": f"{url}/v1",   # legacy openai<1.0 name
+                "AIR_GATEWAY_URL": url,
+                "AIR_SANDBOX": "1",
+            })
+            with open(os.path.join(self.sandbox_dir, "agent.stdout"), "wb") as out, \
+                 open(os.path.join(self.sandbox_dir, "agent.stderr"), "wb") as err:
+                try:
+                    proc = subprocess.run(command, env=env, timeout=timeout,
+                                          stdout=out, stderr=err)
+                    exit_code = proc.returncode
+                except subprocess.TimeoutExpired:
+                    exit_code = -1
+        finally:
+            self._stop_gateway()
+
+        # Records are written asynchronously off the request path; give the
+        # last background write a moment to land.
+        time.sleep(0.5)
+        return self._analyze(exit_code, time.monotonic() - started)
+
+    # -- analysis and artifacts -------------------------------------------
+
+    def _analyze(self, exit_code: int, duration: float) -> SandboxVerdict:
+        engine = ReplayEngine(runs_dir=self.runs_dir)
+        total = engine.load()
+        chain = engine.verify_chain()
+        stats = engine.get_stats() or {}
+        errors = stats.get("statuses", {}).get("error", 0)
+
+        reasons = []
+        if exit_code == -1:
+            reasons.append("agent timed out")
+        elif exit_code != 0:
+            reasons.append(f"agent exited nonzero ({exit_code})")
+        if total == 0:
+            reasons.append("no LLM calls were recorded - agent did not route "
+                           "through the sandbox gateway")
+        if not chain.intact:
+            reasons.append(f"audit chain broken at record {chain.first_break_at}")
+        elif total > 0 and chain.records_with_hash < total:
+            reasons.append(
+                f"only {chain.records_with_hash} of {total} records are chained")
+        if errors:
+            reasons.append(f"{errors} LLM call(s) errored")
+
+        verdict = SandboxVerdict(
+            passed=not reasons,
+            reasons=reasons,
+            agent_exit_code=exit_code,
+            total_calls=total,
+            error_calls=errors,
+            chain_intact=chain.intact,
+            chain_verified=chain.verified_records,
+            models=stats.get("models", {}),
+            total_tokens=stats.get("total_tokens", 0),
+            duration_seconds=round(duration, 2),
+            sandbox_dir=self.sandbox_dir,
+        )
+
+        verdict.lake_dir = self._export_lake()
+        verdict.evidence_path = self._export_evidence(verdict)
+
+        with open(os.path.join(self.sandbox_dir, "report.json"), "w") as f:
+            json.dump(asdict(verdict), f, indent=2)
+        return verdict
+
+    def _export_lake(self) -> Optional[str]:
+        try:
+            from air_blackbox.lake import export_records
+        except ImportError:
+            return None
+        lake_dir = os.path.join(self.sandbox_dir, "air-lake")
+        try:
+            export_records(self.runs_dir, lake_dir)
+            return lake_dir
+        except Exception:
+            return None
+
+    def _export_evidence(self, verdict: SandboxVerdict) -> Optional[str]:
+        """Package the session as a signed .air-evidence ZIP (the graduation
+        artifact). Uses the same bundle generator as `air-blackbox export`."""
+        try:
+            from air_blackbox.export.evidence_bundle import generate_evidence_zip
+        except ImportError:
+            return None
+        engine = ReplayEngine(runs_dir=self.runs_dir)
+        engine.load()
+        records = engine._raw_records
+        key = self._signing_key()
+        try:
+            return generate_evidence_zip(
+                chain_entries=records,
+                scan_results={"sandbox_verdict": asdict(verdict)},
+                signing_key=key,
+                output_dir=self.sandbox_dir,
+            )
+        except Exception:
+            return None
+
+    def _signing_key(self) -> str:
+        try:
+            with open(os.path.join(self.runs_dir, ".air-signing-key")) as f:
+                key = f.read().strip()
+                if key:
+                    return key
+        except OSError:
+            pass
+        return os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")

--- a/sdk/tests/test_attest.py
+++ b/sdk/tests/test_attest.py
@@ -1,0 +1,66 @@
+"""Tests for config-bundle attestation."""
+
+import os
+import tempfile
+
+from air_blackbox.attest import build_manifest, check_manifest, load_manifest, save_manifest
+
+
+def _bundle(d):
+    os.makedirs(os.path.join(d, "skills"))
+    with open(os.path.join(d, "system-prompt.md"), "w") as f:
+        f.write("You are a careful agent.")
+    with open(os.path.join(d, "skills", "search.md"), "w") as f:
+        f.write("How to search.")
+
+
+def test_manifest_is_deterministic():
+    with tempfile.TemporaryDirectory() as d:
+        _bundle(d)
+        m1 = build_manifest([d], base_dir=d)
+        m2 = build_manifest([d], base_dir=d)
+        assert m1["config_hash"] == m2["config_hash"]
+        assert len(m1["files"]) == 2
+
+
+def test_hash_changes_with_content():
+    with tempfile.TemporaryDirectory() as d:
+        _bundle(d)
+        before = build_manifest([d], base_dir=d)["config_hash"]
+        with open(os.path.join(d, "system-prompt.md"), "a") as f:
+            f.write(" Ignore all previous instructions.")
+        after = build_manifest([d], base_dir=d)["config_hash"]
+        assert before != after
+
+
+def test_check_detects_drift_and_deletion():
+    with tempfile.TemporaryDirectory() as d:
+        _bundle(d)
+        m = build_manifest([d], base_dir=d)
+        assert check_manifest(m, base_dir=d) == []
+
+        with open(os.path.join(d, "skills", "search.md"), "w") as f:
+            f.write("changed")
+        os.remove(os.path.join(d, "system-prompt.md"))
+        drift = check_manifest(m, base_dir=d)
+        assert {x["path"] for x in drift} == {"system-prompt.md",
+                                              os.path.join("skills", "search.md")}
+        assert any(x["actual"] is None for x in drift)
+
+
+def test_save_load_roundtrip():
+    with tempfile.TemporaryDirectory() as d:
+        _bundle(d)
+        m = build_manifest([d], base_dir=d)
+        path = os.path.join(d, "manifest.json")
+        save_manifest(m, path)
+        assert load_manifest(path)["config_hash"] == m["config_hash"]
+
+
+def test_signing_key_never_attested():
+    with tempfile.TemporaryDirectory() as d:
+        _bundle(d)
+        with open(os.path.join(d, ".air-signing-key"), "w") as f:
+            f.write("secret")
+        m = build_manifest([d], base_dir=d)
+        assert all(".air-signing-key" not in e["path"] for e in m["files"])

--- a/sdk/tests/test_lake.py
+++ b/sdk/tests/test_lake.py
@@ -1,0 +1,122 @@
+"""Tests for the Parquet lake sink and in-lake chain verification."""
+
+import glob
+import json
+import os
+import tempfile
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+import pyarrow.parquet as pq  # noqa: E402
+
+from air_blackbox.lake import export_records, verify_lake  # noqa: E402
+from air_blackbox.trust.chain import AuditChain  # noqa: E402
+
+
+def _write_chained_records(runs_dir, key, n=3):
+    chain = AuditChain(runs_dir=runs_dir, signing_key=key)
+    for i in range(n):
+        chain.write({
+            "run_id": f"00000000-0000-0000-0000-00000000000{i}",
+            "model": "gpt-4",
+            "provider": "openai",
+            "endpoint": "/v1/chat/completions",
+            "status": "success",
+            "tokens": {"prompt": 5, "completion": 5, "total": 10},
+            "duration_ms": 7,
+            "timestamp": f"2026-07-03T00:00:0{i}Z",
+        })
+
+
+def test_export_and_verify_intact():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "lake-key")
+        count = export_records(runs, lake)
+        assert count == 3
+
+        result = verify_lake(lake, signing_key="lake-key")
+        assert result.intact
+        assert result.chain.verified_records == 3
+        assert not result.column_mismatches
+
+
+def test_export_is_incremental():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "lake-key")
+        assert export_records(runs, lake) == 3
+        # Re-export: nothing new.
+        assert export_records(runs, lake) == 0
+
+        # A new record lands, only it gets exported.
+        chain = AuditChain(runs_dir=runs, signing_key="lake-key")
+        # Continue the chain manually: AuditChain restarts at genesis, so
+        # write to a fresh dir and copy - simpler to just verify count here.
+        extra_runs = os.path.join(runs, "extra")
+        os.makedirs(extra_runs)
+        rec = {"run_id": "11111111-0000-0000-0000-000000000000",
+               "model": "gpt-4", "status": "success",
+               "timestamp": "2026-07-03T00:01:00Z"}
+        with open(os.path.join(extra_runs, rec["run_id"] + ".air.json"), "w") as f:
+            json.dump(rec, f)
+        assert export_records(runs, lake) == 1
+
+
+def test_tampered_record_json_breaks_chain():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "lake-key")
+        export_records(runs, lake)
+
+        # Tamper with the record_json payload of the middle record inside
+        # the Parquet file itself.
+        part = glob.glob(os.path.join(lake, "**", "*.parquet"), recursive=True)[0]
+        table = pq.read_table(part)
+        rows = table.to_pylist()
+        for row in rows:
+            rec = json.loads(row["record_json"])
+            if rec["run_id"].endswith("1"):
+                rec["model"] = "TAMPERED"
+                row["record_json"] = json.dumps(rec, sort_keys=True)
+        pq.write_table(pa.Table.from_pylist(rows, schema=table.schema), part)
+
+        result = verify_lake(lake, signing_key="lake-key")
+        assert not result.intact
+        assert not result.chain.intact
+        assert result.chain.first_break_run_id == "00000000-0000-0000-0000-000000000001"
+
+
+def test_inconsistent_column_detected():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "lake-key")
+        export_records(runs, lake)
+
+        # Tamper with a flattened SQL column while leaving record_json (and
+        # therefore the chain) untouched.
+        part = glob.glob(os.path.join(lake, "**", "*.parquet"), recursive=True)[0]
+        table = pq.read_table(part)
+        rows = table.to_pylist()
+        rows[0]["model"] = "TAMPERED"
+        pq.write_table(pa.Table.from_pylist(rows, schema=table.schema), part)
+
+        result = verify_lake(lake, signing_key="lake-key")
+        assert result.chain.intact          # the verified payload is fine
+        assert not result.intact            # but the table lies
+        assert any(m["column"] == "model" for m in result.column_mismatches)
+
+
+def test_wrong_key_breaks_chain():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "lake-key")
+        export_records(runs, lake)
+        result = verify_lake(lake, signing_key="wrong-key")
+        assert not result.intact
+
+
+def test_keyfile_resolution():
+    with tempfile.TemporaryDirectory() as runs, tempfile.TemporaryDirectory() as lake:
+        _write_chained_records(runs, "keyfile-key")
+        with open(os.path.join(runs, ".air-signing-key"), "w") as f:
+            f.write("keyfile-key\n")
+        export_records(runs, lake)
+        result = verify_lake(lake, runs_dir=runs)
+        assert result.intact

--- a/sdk/tests/test_lake.py
+++ b/sdk/tests/test_lake.py
@@ -49,9 +49,6 @@ def test_export_is_incremental():
         assert export_records(runs, lake) == 0
 
         # A new record lands, only it gets exported.
-        chain = AuditChain(runs_dir=runs, signing_key="lake-key")
-        # Continue the chain manually: AuditChain restarts at genesis, so
-        # write to a fresh dir and copy - simpler to just verify count here.
         extra_runs = os.path.join(runs, "extra")
         os.makedirs(extra_runs)
         rec = {"run_id": "11111111-0000-0000-0000-000000000000",

--- a/sdk/tests/test_replay_verify.py
+++ b/sdk/tests/test_replay_verify.py
@@ -1,0 +1,89 @@
+"""Regression tests for ReplayEngine.verify_chain.
+
+The chain hash is computed by trust.chain.AuditChain.write as
+HMAC-SHA256(key, prev_hash || json.dumps(record_without_chain_hash, sort_keys=True))
+with prev_hash starting at b"genesis" and advancing to the raw digest.
+The replay engine must verify exactly that construction, and must not
+report "verified" for records that carry no chain_hash at all.
+"""
+
+import json
+import os
+import tempfile
+
+from air_blackbox.replay.engine import ReplayEngine
+from air_blackbox.trust.chain import AuditChain
+
+
+def _write_chained_records(runs_dir, key, n=3):
+    chain = AuditChain(runs_dir=runs_dir, signing_key=key)
+    for i in range(n):
+        chain.write({
+            "run_id": f"00000000-0000-0000-0000-00000000000{i}",
+            "model": "gpt-4",
+            "tokens": {"total": 10},
+            "status": "success",
+            "timestamp": f"2026-07-03T00:00:0{i}Z",
+        })
+
+
+def test_untampered_trust_layer_chain_verifies():
+    with tempfile.TemporaryDirectory() as d:
+        _write_chained_records(d, "test-key")
+        engine = ReplayEngine(runs_dir=d)
+        engine.load()
+        result = engine.verify_chain(signing_key="test-key")
+        assert result.intact
+        assert result.verified_records == 3
+        assert result.records_with_hash == 3
+
+
+def test_tampered_record_breaks_chain():
+    with tempfile.TemporaryDirectory() as d:
+        _write_chained_records(d, "test-key")
+        # Tamper with the middle record's content.
+        path = os.path.join(d, "00000000-0000-0000-0000-000000000001.air.json")
+        with open(path) as f:
+            rec = json.load(f)
+        rec["model"] = "TAMPERED"
+        with open(path, "w") as f:
+            json.dump(rec, f)
+
+        engine = ReplayEngine(runs_dir=d)
+        engine.load()
+        result = engine.verify_chain(signing_key="test-key")
+        assert not result.intact
+        assert result.first_break_at == 1
+        assert result.first_break_run_id == "00000000-0000-0000-0000-000000000001"
+
+
+def test_wrong_key_breaks_chain():
+    with tempfile.TemporaryDirectory() as d:
+        _write_chained_records(d, "test-key")
+        engine = ReplayEngine(runs_dir=d)
+        engine.load()
+        result = engine.verify_chain(signing_key="wrong-key")
+        assert not result.intact
+
+
+def test_records_without_chain_hash_are_not_counted_verified():
+    with tempfile.TemporaryDirectory() as d:
+        # Gateway-style records: no chain_hash field.
+        for i in range(3):
+            rec = {
+                "run_id": f"11111111-0000-0000-0000-00000000000{i}",
+                "model": "gpt-4",
+                "tokens": {"total": 10},
+                "status": "success",
+                "timestamp": f"2026-07-03T00:00:0{i}Z",
+            }
+            with open(os.path.join(d, rec["run_id"] + ".air.json"), "w") as f:
+                json.dump(rec, f)
+
+        engine = ReplayEngine(runs_dir=d)
+        engine.load()
+        result = engine.verify_chain(signing_key="test-key")
+        # Nothing to check, so nothing may be reported as verified.
+        assert result.records_with_hash == 0
+        assert result.verified_records == 0
+        assert result.total_records == 3

--- a/sdk/tests/test_replay_verify.py
+++ b/sdk/tests/test_replay_verify.py
@@ -66,6 +66,32 @@ def test_wrong_key_breaks_chain():
         assert not result.intact
 
 
+def test_legacy_unchained_records_do_not_break_the_chain():
+    """Records written before chaining was enabled sit outside the chain:
+    they must not advance the chain state or cause false breaks."""
+    with tempfile.TemporaryDirectory() as d:
+        # A legacy record with the earliest timestamp and no chain_hash.
+        legacy = {
+            "run_id": "99999999-0000-0000-0000-000000000000",
+            "model": "gpt-3.5",
+            "tokens": {"total": 5},
+            "status": "success",
+            "timestamp": "2026-01-01T00:00:00Z",
+        }
+        with open(os.path.join(d, legacy["run_id"] + ".air.json"), "w") as f:
+            json.dump(legacy, f)
+
+        _write_chained_records(d, "test-key")
+
+        engine = ReplayEngine(runs_dir=d)
+        engine.load()
+        result = engine.verify_chain(signing_key="test-key")
+        assert result.intact
+        assert result.verified_records == 3
+        assert result.records_with_hash == 3
+        assert result.total_records == 4
+
+
 def test_records_without_chain_hash_are_not_counted_verified():
     with tempfile.TemporaryDirectory() as d:
         # Gateway-style records: no chain_hash field.

--- a/sdk/tests/test_sandbox.py
+++ b/sdk/tests/test_sandbox.py
@@ -1,0 +1,88 @@
+"""Tests for the compliance sandbox (external-gateway mode).
+
+Managed-gateway mode needs the Go binary and is exercised end-to-end in CI's
+Go jobs and manually; these tests drive the orchestration and verdict logic
+with an "agent" that writes chained records the way a gateway would.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+from air_blackbox.sandbox import SandboxSession
+
+# An agent that records N chained calls into the sandbox runs dir, like a
+# gateway would, then exits with the requested code.
+AGENT = """
+import sys
+sys.path.insert(0, {sdk_path!r})
+from air_blackbox.trust.chain import AuditChain
+chain = AuditChain(runs_dir={runs_dir!r}, signing_key="sandbox-test-key")
+for i in range(int(sys.argv[1])):
+    chain.write({{
+        "run_id": f"00000000-0000-0000-0000-00000000000{{i}}",
+        "model": "gpt-4", "status": sys.argv[3] if len(sys.argv) > 3 else "success",
+        "tokens": {{"total": 10}},
+        "timestamp": f"2026-07-03T00:00:0{{i}}Z",
+    }})
+sys.exit(int(sys.argv[2]))
+"""
+
+SDK_PATH = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _run(n_calls, exit_code, status="success"):
+    with tempfile.TemporaryDirectory() as d:
+        runs = os.path.join(d, "runs")
+        os.makedirs(runs)
+        with open(os.path.join(runs, ".air-signing-key"), "w") as f:
+            f.write("sandbox-test-key\n")
+        session = SandboxSession(
+            sandbox_dir=d, gateway_url="http://unused:1", runs_dir=runs)
+        agent = AGENT.format(sdk_path=os.path.abspath(SDK_PATH), runs_dir=runs)
+        verdict = session.run(
+            [sys.executable, "-c", agent, str(n_calls), str(exit_code), status],
+            timeout=60)
+        report = json.load(open(os.path.join(d, "report.json")))
+        # The temp dir vanishes when this function returns, so capture
+        # artifact existence while it still exists.
+        artifacts = {
+            "evidence": bool(verdict.evidence_path)
+                        and os.path.exists(verdict.evidence_path),
+            "lake": bool(verdict.lake_dir) and os.path.isdir(verdict.lake_dir),
+        }
+        return verdict, report, artifacts
+
+
+def test_clean_run_graduates():
+    verdict, report, artifacts = _run(n_calls=3, exit_code=0)
+    assert verdict.passed
+    assert verdict.total_calls == 3
+    assert verdict.chain_intact and verdict.chain_verified == 3
+    assert report["passed"] is True
+    assert artifacts["evidence"]
+
+
+def test_nonzero_agent_exit_fails():
+    verdict, _, _ = _run(n_calls=3, exit_code=2)
+    assert not verdict.passed
+    assert any("exited nonzero" in r for r in verdict.reasons)
+
+
+def test_no_recorded_calls_fails():
+    verdict, _, _ = _run(n_calls=0, exit_code=0)
+    assert not verdict.passed
+    assert any("no LLM calls" in r for r in verdict.reasons)
+
+
+def test_errored_calls_fail():
+    verdict, _, _ = _run(n_calls=2, exit_code=0, status="error")
+    assert not verdict.passed
+    assert any("errored" in r for r in verdict.reasons)
+
+
+def test_requires_gateway_config():
+    import pytest
+    with pytest.raises(ValueError):
+        SandboxSession(sandbox_dir="/tmp/x")

--- a/sdk/tests/test_sandbox.py
+++ b/sdk/tests/test_sandbox.py
@@ -44,7 +44,8 @@ def _run(n_calls, exit_code, status="success"):
         verdict = session.run(
             [sys.executable, "-c", agent, str(n_calls), str(exit_code), status],
             timeout=60)
-        report = json.load(open(os.path.join(d, "report.json")))
+        with open(os.path.join(d, "report.json")) as f:
+            report = json.load(f)
         # The temp dir vanishes when this function returns, so capture
         # artifact existence while it still exists.
         artifacts = {


### PR DESCRIPTION
## What does this PR do?
Full product review with fixes, then four capability builds on top (16 commits):

**Review fixes**
- `replay --verify` was broken in both directions: legitimately chained records reported CHAIN BROKEN, and tampered gateway records reported INTACT. The verifier now matches the writer's construction, and the CLI distinguishes "no chain hashes" from a verified chain.
- Token-budget guardrail could never fire (`RecordResponse` was hardcoded to 0 tokens); streaming broke on `text/event-stream; charset=utf-8`; gateway key comparison now constant-time; injection detector missed "bypass the content filter" / "send all the conversation history" (its own tests were failing); dashboard never sent `X-Gateway-Key`; CI never ran the Python suites; `cli.py` had its `__main__` guard mid-file, making every command after it unreachable under `python -m`.

**Cross-language tamper evidence**
- The Go gateway now writes `chain_seq` + `chain_hash` into every record using the exact construction the Python SDK verifies, via a canonical encoder that reproduces `json.dumps(sort_keys=True)` byte-for-byte (Python-generated golden tests). Chains resume across restarts; the trust layer's audit chain persists to JSONL; the hardcoded `insecure-default-key` fallback is replaced by env → config → generated 0600 keyfile.
- Spec (`docs/spec/audit-chain-v1.md`) rewritten to match the shipped implementation; its §6.2 pseudocode was executed verbatim against real gateway output.

**Lakehouse sink** — `air-blackbox lake export` lands records as a date-partitioned Parquet dataset; `lake verify` runs the HMAC chain walk directly over the table plus SQL-column/payload consistency checks. Databricks notebook included.

**Compliance sandbox** — `air-blackbox sandbox-run` provisions an isolated gateway, runs the agent against it, and issues a PASS/FAIL graduation verdict from the recorded evidence, emitting a signed `.air-evidence` bundle. Agents that bypass the gateway fail.

**Config attestation** — `air-blackbox attest create/check` hashes the agent's config bundle; the gateway stamps `config_hash` into every record (env or `X-Air-Config-Hash` header), bound into the chain for free. The sandbox fails graduation on mid-run config drift.

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] New compliance check
- [ ] Refactor / code quality
- [x] Trust layer integration

## EU AI Act articles affected
Article 12 (record-keeping: chained, verifiable gateway records; persistent audit chain), Article 9 (risk management: sandbox pre-deployment testing gate), Article 15 (accuracy/robustness: guardrail fixes, injection detector fixes).

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (Go: full `-race` suite; Python: 113 tests)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (all record fields additive; unchained writers unchanged)

## Additional notes
Every feature was proven live end-to-end in-session: gateway → chained records verified by the Python CLI across a restart; tampered records/lake rows detected at the exact record; sandbox PASS and FAIL paths; evidence bundles self-verify. Recommend **squash merge**: it keeps `noreply@anthropic.com` commit authorship off `main`, which also removes the farmed contributor attribution discussed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_