### PR TITLE
Governance: covenant enforcement, MCP server for Claude, remote transport + OAuth, session passport

### DIFF
--- a/deploy/mcp/Dockerfile
+++ b/deploy/mcp/Dockerfile
@@ -1,0 +1,17 @@
+# AIR Blackbox governance MCP server - remote connector for claude.ai
+# Build from repo root:  docker build -f deploy/mcp/Dockerfile -t air-mcp .
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY pyproject.toml README.md ./
+COPY sdk/ sdk/
+RUN pip install --no-cache-dir ".[mcp,gate]"
+
+# Records persist here; mount a volume in production.
+ENV AIR_RUNS_DIR=/data/runs \
+    AIR_MCP_TRANSPORT=http \
+    AIR_MCP_PORT=8085
+VOLUME /data
+EXPOSE 8085
+
+CMD ["air-blackbox-mcp"]

--- a/deploy/mcp/README.md
+++ b/deploy/mcp/README.md
@@ -1,0 +1,61 @@
+# AIR Blackbox Governance MCP Server
+
+Governance inside Claude: record every agent action into a tamper-evident
+chain, enforce a covenant before acting, and export signed evidence — as a
+connector, on your own domain.
+
+## Local (Claude Desktop)
+
+```bash
+pip install air-blackbox[mcp]
+```
+
+```json
+{"mcpServers": {"air-blackbox": {"command": "air-blackbox-mcp",
+  "env": {"AIR_COVENANT": "/path/to/recruiting-screener.covenant.yaml"}}}}
+```
+
+## Remote (claude.ai custom connector) — tethered to airblackbox.ai
+
+```bash
+# from repo root
+fly launch --copy-config --no-deploy        # app: air-mcp
+fly volumes create air_data --size 1
+fly secrets set TRUST_SIGNING_KEY=$(openssl rand -hex 32)
+
+# --- OAuth (pick one) ---
+# Production: verify claude.ai tokens against your IdP (Auth0/WorkOS/Okta/...)
+fly secrets set AIR_MCP_INTROSPECTION_URL=https://YOUR-IDP/oauth/introspect
+fly secrets set AIR_MCP_INTROSPECTION_AUTH="Basic <base64 client:secret>"
+# Self-host: one static bearer token per tenant
+fly secrets set AIR_MCP_TOKENS="tok-alice:recruiter-alice,tok-bob:recruiter-bob"
+
+fly deploy
+fly certs add mcp.airblackbox.ai
+# DNS: CNAME mcp.airblackbox.ai -> air-mcp.fly.dev
+```
+
+Then in claude.ai: **Settings → Connectors → Add custom connector →**
+`https://mcp.airblackbox.ai/mcp`
+
+## OAuth model
+
+The server is an OAuth 2.1 **resource server**: it verifies bearer tokens,
+it does not issue them. `/.well-known/oauth-protected-resource` advertises
+the auth server so claude.ai can negotiate. No token → `401`.
+
+**Tenant isolation:** the verified token subject keys a per-tenant chain,
+so each connected user's records, verification, and evidence bundle are
+fully separate — one recruiter's evidence never mixes with another's.
+
+Without `AIR_MCP_INTROSPECTION_URL` or `AIR_MCP_TOKENS` set, the server runs
+open (correct for local stdio use, never for a public deployment).
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `record_action` | Write a covenant-evaluated action into the chain (forbidden → recorded as blocked; approval-required → instructs Claude to get human sign-off). |
+| `check_covenant` | Ask the policy before acting. |
+| `verify_chain` | Prove integrity of this tenant's records. |
+| `export_evidence` | Package this tenant's session into a signed `.air-evidence` ZIP. |

--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -20,7 +20,16 @@ primary_region = "iad"
   AIR_MCP_TRANSPORT = "http"
   AIR_MCP_PORT = "8085"
   AIR_RUNS_DIR = "/data/runs"
+  AIR_MCP_ISSUER_URL = "https://mcp.airblackbox.ai"
   # AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
+  #
+  # OAuth (resource-server). Production: point at your IdP's introspection
+  # endpoint so claude.ai tokens are verified per request and tenants isolate
+  # by subject:
+  #   fly secrets set AIR_MCP_INTROSPECTION_URL=https://YOUR-IDP/oauth/introspect
+  #   fly secrets set AIR_MCP_INTROSPECTION_AUTH="Basic <base64 client:secret>"
+  # Self-host without an IdP: issue static bearer tokens (one per tenant):
+  #   fly secrets set AIR_MCP_TOKENS="tok1:recruiter-a,tok2:recruiter-b"
 
 [mounts]
   source = "air_data"

--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -1,0 +1,33 @@
+# Deploy the governance MCP server and tether it to airblackbox.ai:
+#
+#   fly launch --copy-config --no-deploy   # from repo root, app name: air-mcp
+#   fly volumes create air_data --size 1
+#   fly secrets set TRUST_SIGNING_KEY=$(openssl rand -hex 32)
+#   fly deploy
+#   fly certs add mcp.airblackbox.ai
+#   # DNS: CNAME  mcp.airblackbox.ai -> air-mcp.fly.dev
+#
+# Then in claude.ai: Settings -> Connectors -> Add custom connector
+#   URL: https://mcp.airblackbox.ai/mcp
+
+app = "air-mcp"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  AIR_MCP_TRANSPORT = "http"
+  AIR_MCP_PORT = "8085"
+  AIR_RUNS_DIR = "/data/runs"
+  # AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
+
+[mounts]
+  source = "air_data"
+  destination = "/data"
+
+[http_service]
+  internal_port = 8085
+  force_https = true
+  auto_stop_machines = false
+  min_machines_running = 1

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,1 +1,0 @@
-"""AIR Blackbox mcp module — part of the gateway monorepo."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ claude = ["claude-agent-sdk>=0.1.0"]
 pdf = ["reportlab>=4.0"]
 gate = ["cryptography>=42.0"]
 lake = ["pyarrow>=14.0"]  # Parquet lake sink + in-lake chain verification
+mcp = ["mcp>=1.0"]  # governance MCP server for Claude (record/enforce/prove)
 pqc = ["oqs>=0.10.0"]  # post-quantum ML-DSA-65 signing (opt-in)
 all = [
     "air-blackbox[langchain]",
@@ -60,12 +61,14 @@ all = [
     "air-blackbox[pdf]",
     "air-blackbox[gate]",
     "air-blackbox[lake]",
+    "air-blackbox[mcp]",
     "air-blackbox[pqc]",
 ]
 
 [project.scripts]
 air-blackbox = "air_blackbox.cli:main"
 air-blackbox-comply-strict = "air_blackbox.precommit:main"
+air-blackbox-mcp = "air_blackbox.mcp_server:main"
 
 [project.urls]
 Homepage = "https://airblackbox.ai"

--- a/sdk/air_blackbox/cli.py
+++ b/sdk/air_blackbox/cli.py
@@ -2211,7 +2211,9 @@ def lake_verify(lake_dir, runs_dir, signing_key):
 @click.option("--timeout", default=600, help="Agent timeout in seconds")
 @click.option("--config", "config_paths", multiple=True,
               help="Attest these config files/dirs and bind every record to their hash")
-def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrails, output, timeout, config_paths):
+@click.option("--covenant", default=None,
+              help="Covenant YAML applied to recorded calls at graduation (needs an llm_call rule)")
+def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrails, output, timeout, config_paths, covenant):
     """Run an agent in a recorded compliance sandbox.
 
     Provisions an isolated gateway, points the agent at it via
@@ -2231,7 +2233,8 @@ def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrail
             sandbox_dir=output, gateway_bin=gateway_bin,
             gateway_url=gateway_url, runs_dir=runs_dir,
             provider_url=provider, guardrails_config=guardrails,
-            config_paths=list(config_paths) or None)
+            config_paths=list(config_paths) or None,
+            covenant_path=covenant)
     except ValueError as e:
         console.print(f"[red]{e}[/]\n")
         raise SystemExit(2)
@@ -2251,6 +2254,8 @@ def sandbox_run(command, gateway_bin, gateway_url, runs_dir, provider, guardrail
     ]
     if verdict.config_hash:
         lines.append(f"  Config attested: {verdict.config_hash[:16]}... (bound into every record)")
+    if verdict.covenant_hash:
+        lines.append(f"  Covenant: {verdict.covenant_hash[:16]}... ({verdict.covenant_violations} violation(s))")
     for reason in verdict.reasons:
         lines.append(f"  [red]- {reason}[/]")
     lines.append("")

--- a/sdk/air_blackbox/gate/examples/linkedin-sourcing.covenant.yaml
+++ b/sdk/air_blackbox/gate/examples/linkedin-sourcing.covenant.yaml
@@ -1,0 +1,31 @@
+# Covenant — LinkedIn Sourcing Session (browser agent)
+#
+# The point is not "hide the automation" - it is to make the agent's
+# activity provably legitimate: bounded, human-approved where it matters,
+# no bulk harvesting. Pair with air_blackbox.passport.BrowserSession; the
+# session passport is the artifact you can show a client or platform.
+
+agent: linkedin-sourcing
+version: "1.0"
+description: "Accountable browser sourcing: read freely, act with a human"
+
+rules:
+  # Viewing and research - permitted (a recruiter would do this by hand)
+  - permit: navigate
+  - permit: read_profile
+  - permit: read_search_results
+  - permit: summarize_profile
+  - permit: draft_message          # draft only; sending is gated below
+
+  # Candidate-facing actions - a human approves each one (anti-spam, and the
+  # GDPR Art 22 / AI Act Art 14 human-in-the-loop requirement)
+  - require_approval: send_message
+  - require_approval: send_connection_request
+  - require_approval: send_inmail
+  - require_approval: endorse
+
+  # Abuse patterns platforms ban accounts for - forbidden outright
+  - forbid: bulk_export
+  - forbid: scrape_search_page
+  - forbid: harvest_emails
+  - forbid: auto_connect_all

--- a/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml
+++ b/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml
@@ -1,0 +1,42 @@
+# Covenant — AI Recruiting / Candidate Screening Agent
+#
+# Addresses automated decision-making (ADM) exposure: GDPR Article 22
+# (no solely automated significant decisions), EU AI Act Annex III
+# (employment = high-risk: Articles 9, 12, 14 apply), NYC Local Law 144,
+# Colorado SB 24-205.
+#
+# The pattern: the agent may READ and SUMMARIZE freely, but every action
+# that affects a candidate's outcome requires human approval. Run under
+# `air-blackbox sandbox-run --covenant` and the recorded evidence is
+# judged against this declaration; in production, the gateway's approval
+# webhook enforces the require_approval rules live.
+
+agent: recruiting-screener
+version: "1.0"
+description: "ADM-safe policy for candidate sourcing and screening agents"
+
+rules:
+  # Research and enrichment - permitted (no candidate-affecting decision)
+  - permit: search_candidates
+  - permit: read_profile
+  - permit: read_resume
+  - permit: summarize_candidate
+  - permit: draft_outreach          # drafting, not sending
+
+  # LLM usage - permitted within bounds
+  - permit: llm_call
+  - forbid: llm_call
+    when: "tokens_total > 100000"   # runaway-agent budget
+
+  # Candidate-affecting decisions - NEVER solely automated (GDPR Art 22,
+  # AI Act Art 14). A human must approve every outcome-changing action.
+  - require_approval: reject_candidate
+  - require_approval: advance_candidate
+  - require_approval: score_candidate
+  - require_approval: rank_candidates
+  - require_approval: send_outreach
+  - require_approval: schedule_interview
+
+  # Hard prohibitions
+  - forbid: infer_protected_attributes   # race, health, religion, etc.
+  - forbid: delete_records               # Article 12 retention

--- a/sdk/air_blackbox/mcp_auth.py
+++ b/sdk/air_blackbox/mcp_auth.py
@@ -1,0 +1,116 @@
+"""OAuth token verification for the AIR Blackbox MCP server.
+
+The server acts as an OAuth 2.1 *resource server*: it does not issue tokens,
+it verifies bearer tokens presented by claude.ai on each request. Two modes,
+selected by environment:
+
+- Introspection (production): set AIR_MCP_INTROSPECTION_URL to an RFC 7662
+  endpoint on your identity provider (Auth0, WorkOS, Okta, Keycloak...).
+  claude.ai obtains a token from that IdP; every MCP request's token is
+  introspected. AIR_MCP_INTROSPECTION_AUTH optionally sets a Bearer/Basic
+  header for the introspection call itself.
+
+- Static tokens (self-host / dev): set AIR_MCP_TOKENS to a comma-separated
+  list of `token:subject:scope1|scope2` triples. Simple, no IdP required,
+  and still gives per-tenant isolation via subject.
+
+The verified subject is what isolates tenants: each subject records into its
+own chain, so one recruiter's evidence never mixes with another's.
+"""
+
+import os
+import time
+from typing import Optional
+
+import httpx
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+from pydantic import AnyHttpUrl
+
+
+class StaticTokenVerifier(TokenVerifier):
+    """Verify against a fixed token->subject map from AIR_MCP_TOKENS."""
+
+    def __init__(self, spec: str):
+        self._tokens = {}
+        for entry in spec.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            parts = entry.split(":")
+            token = parts[0]
+            subject = parts[1] if len(parts) > 1 and parts[1] else token[:12]
+            scopes = parts[2].split("|") if len(parts) > 2 and parts[2] else []
+            self._tokens[token] = (subject, scopes)
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        entry = self._tokens.get(token)
+        if not entry:
+            return None
+        subject, scopes = entry
+        return AccessToken(token=token, client_id=subject, subject=subject,
+                           scopes=scopes, expires_at=None)
+
+
+class IntrospectionTokenVerifier(TokenVerifier):
+    """Verify via RFC 7662 token introspection against an external IdP."""
+
+    def __init__(self, url: str, auth_header: Optional[str] = None):
+        self._url = url
+        self._auth_header = auth_header
+
+    async def verify_token(self, token: str) -> Optional[AccessToken]:
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        if self._auth_header:
+            headers["Authorization"] = self._auth_header
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(self._url, data={"token": token},
+                                         headers=headers)
+        except httpx.HTTPError:
+            return None
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        if not data.get("active"):
+            return None
+        exp = data.get("exp")
+        if exp and exp < time.time():
+            return None
+        scopes = data.get("scope", "")
+        subject = data.get("sub") or data.get("client_id") or "unknown"
+        return AccessToken(
+            token=token,
+            client_id=data.get("client_id", subject),
+            subject=subject,
+            scopes=scopes.split() if isinstance(scopes, str) else list(scopes),
+            expires_at=int(exp) if exp else None,
+        )
+
+
+def build_auth():
+    """Return (verifier, AuthSettings) if OAuth is configured, else (None, None).
+
+    OAuth engages when AIR_MCP_INTROSPECTION_URL or AIR_MCP_TOKENS is set.
+    Unset means the server runs open (fine for local Claude Desktop / stdio).
+    """
+    introspection = os.environ.get("AIR_MCP_INTROSPECTION_URL", "")
+    static = os.environ.get("AIR_MCP_TOKENS", "")
+    if not introspection and not static:
+        return None, None
+
+    if introspection:
+        verifier = IntrospectionTokenVerifier(
+            introspection, os.environ.get("AIR_MCP_INTROSPECTION_AUTH") or None)
+    else:
+        verifier = StaticTokenVerifier(static)
+
+    issuer = os.environ.get("AIR_MCP_ISSUER_URL", "https://mcp.airblackbox.ai")
+    resource = os.environ.get("AIR_MCP_RESOURCE_URL", issuer)
+    required = os.environ.get("AIR_MCP_REQUIRED_SCOPES", "")
+    settings = AuthSettings(
+        issuer_url=AnyHttpUrl(issuer),
+        resource_server_url=AnyHttpUrl(resource),
+        required_scopes=[s for s in required.split(",") if s] or None,
+    )
+    return verifier, settings

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -20,7 +20,6 @@ Claude Desktop config:
     "args": ["-m", "air_blackbox.mcp_server"]}}}
 """
 
-import json
 import os
 import uuid
 from datetime import datetime, timezone
@@ -28,7 +27,7 @@ from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
 
-from air_blackbox.gate.covenant import Covenant, RuleAction
+from air_blackbox.gate.covenant import Covenant
 from air_blackbox.mcp_auth import build_auth
 from air_blackbox.replay.engine import ReplayEngine
 from air_blackbox.trust.chain import AuditChain
@@ -63,6 +62,8 @@ def _current_tenant() -> str:
         if token and token.subject:
             return _safe_tenant(token.subject)
     except Exception:
+        # Any failure to read the auth context (no request scope, middleware
+        # not active) intentionally falls back to the isolated local tenant.
         pass
     return "_local"
 

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -121,7 +121,19 @@ def export_evidence() -> str:
 
 
 def main():
-    app.run()
+    """Run over stdio (Claude Desktop) or HTTP (claude.ai custom connector).
+
+    AIR_MCP_TRANSPORT=http serves streamable HTTP on AIR_MCP_HOST:AIR_MCP_PORT
+    (default 0.0.0.0:8085, endpoint /mcp) - put it behind TLS at e.g.
+    https://mcp.airblackbox.ai/mcp and add it in claude.ai as a custom
+    connector. Default is stdio for local Claude Desktop use.
+    """
+    if os.environ.get("AIR_MCP_TRANSPORT", "stdio") == "http":
+        app.settings.host = os.environ.get("AIR_MCP_HOST", "0.0.0.0")
+        app.settings.port = int(os.environ.get("AIR_MCP_PORT", "8085"))
+        app.run(transport="streamable-http")
+    else:
+        app.run()
 
 
 if __name__ == "__main__":

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -1,0 +1,128 @@
+"""AIR Blackbox MCP server - governance inside Claude itself.
+
+Connect this to Claude (Desktop or claude.ai custom connector) and every
+agent action Claude takes can be declared, recorded, and proven:
+
+- record_action: writes a chained, tamper-evident AIR record for an action
+  (covenant-evaluated first when one is loaded). This is the flight
+  recorder for Claude-native workflows the gateway cannot see.
+- check_covenant: ask before acting - permit / forbid / require_approval.
+- verify_chain: live integrity check over everything recorded so far.
+- export_evidence: package the session into a signed .air-evidence ZIP.
+
+Storage: records land in AIR_RUNS_DIR (default ~/.air-blackbox/runs), the
+same format the gateway writes, so lake export, replay, and evidence
+tooling all apply unchanged.
+
+Run:  python -m air_blackbox.mcp_server
+Claude Desktop config:
+  {"mcpServers": {"air-blackbox": {"command": "python",
+    "args": ["-m", "air_blackbox.mcp_server"]}}}
+"""
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from air_blackbox.gate.covenant import Covenant, RuleAction
+from air_blackbox.replay.engine import ReplayEngine
+from air_blackbox.trust.chain import AuditChain
+
+RUNS_DIR = os.environ.get(
+    "AIR_RUNS_DIR", os.path.expanduser("~/.air-blackbox/runs"))
+COVENANT_PATH = os.environ.get("AIR_COVENANT", "")
+
+app = FastMCP("air-blackbox")
+_chain = AuditChain(runs_dir=RUNS_DIR)
+_covenant: Optional[Covenant] = (
+    Covenant.from_yaml(COVENANT_PATH) if COVENANT_PATH else None)
+
+
+@app.tool()
+def record_action(action: str, detail: str = "", model: str = "",
+                  tokens_total: int = 0, category: str = "") -> str:
+    """Record an agent action into the tamper-evident audit chain.
+
+    Call this for every consequential step you take (profile read,
+    outreach draft, decision, message sent). If a covenant is loaded and
+    forbids the action, it is recorded as BLOCKED and you must not
+    proceed with it.
+    """
+    decision = "permit"
+    if _covenant:
+        context = {"model": model, "tokens_total": tokens_total,
+                   "category": category, "detail": detail}
+        decision = _covenant.evaluate(action, context).value
+
+    record = {
+        "run_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "type": "agent_action",
+        "action": action,
+        "detail": detail[:2000],
+        "model": model,
+        "status": "blocked" if decision == "forbid" else "success",
+        "covenant_decision": decision,
+        "tokens": {"total": tokens_total},
+    }
+    if _covenant:
+        record["covenant_hash"] = _covenant.hash
+    chain_hash = _chain.write(record)
+
+    if decision == "forbid":
+        return (f"BLOCKED by covenant (recorded, chain_hash={chain_hash}). "
+                f"Do not perform this action.")
+    if decision == "require_approval":
+        return (f"Recorded (chain_hash={chain_hash}) but this action "
+                f"REQUIRES HUMAN APPROVAL before you proceed. Ask the user "
+                f"to explicitly approve, then record the approval.")
+    return f"Recorded, chain_hash={chain_hash}"
+
+
+@app.tool()
+def check_covenant(action: str, category: str = "") -> str:
+    """Check what the loaded covenant says about an action before doing it."""
+    if not _covenant:
+        return "No covenant loaded (set AIR_COVENANT). Default: unrestricted."
+    decision = _covenant.evaluate(action, {"category": category})
+    return f"Covenant '{_covenant.agent}': {action} -> {decision.value}"
+
+
+@app.tool()
+def verify_chain() -> str:
+    """Verify the integrity of everything recorded so far this deployment."""
+    engine = ReplayEngine(runs_dir=RUNS_DIR)
+    total = engine.load()
+    result = engine.verify_chain()
+    if result.intact:
+        return (f"CHAIN INTACT: {result.verified_records} of {total} records "
+                f"verified. No tampering detected.")
+    return (f"CHAIN BROKEN at record {result.first_break_at} "
+            f"(run {result.first_break_run_id}).")
+
+
+@app.tool()
+def export_evidence() -> str:
+    """Package all recorded actions into a signed .air-evidence ZIP."""
+    from air_blackbox.export.evidence_bundle import generate_evidence_zip
+    engine = ReplayEngine(runs_dir=RUNS_DIR)
+    engine.load()
+    key = os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")
+    path = generate_evidence_zip(
+        chain_entries=engine._raw_records,
+        scan_results={"source": "air-blackbox MCP server",
+                      "records": len(engine._raw_records)},
+        signing_key=key, output_dir=os.path.dirname(RUNS_DIR) or ".")
+    return f"Evidence bundle written: {path} ({len(engine._raw_records)} records)"
+
+
+def main():
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -29,6 +29,7 @@ from typing import Optional
 from mcp.server.fastmcp import FastMCP
 
 from air_blackbox.gate.covenant import Covenant, RuleAction
+from air_blackbox.mcp_auth import build_auth
 from air_blackbox.replay.engine import ReplayEngine
 from air_blackbox.trust.chain import AuditChain
 
@@ -36,10 +37,46 @@ RUNS_DIR = os.environ.get(
     "AIR_RUNS_DIR", os.path.expanduser("~/.air-blackbox/runs"))
 COVENANT_PATH = os.environ.get("AIR_COVENANT", "")
 
-app = FastMCP("air-blackbox")
-_chain = AuditChain(runs_dir=RUNS_DIR)
+_auth_verifier, _auth_settings = build_auth()
+app = FastMCP("air-blackbox",
+              token_verifier=_auth_verifier, auth=_auth_settings)
 _covenant: Optional[Covenant] = (
     Covenant.from_yaml(COVENANT_PATH) if COVENANT_PATH else None)
+
+# Per-tenant chains, keyed by the authenticated OAuth subject. Without auth
+# every request shares the single "_local" tenant.
+_chains: dict = {}
+
+
+def _safe_tenant(subject: str) -> str:
+    # Keep tenant ids filesystem-safe; never let a subject escape RUNS_DIR.
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in subject)[:64]
+
+
+def _current_tenant() -> str:
+    """Resolve the authenticated subject for this request, or the local tenant."""
+    if _auth_verifier is None:
+        return "_local"
+    try:
+        from mcp.server.auth.middleware.auth_context import get_access_token
+        token = get_access_token()
+        if token and token.subject:
+            return _safe_tenant(token.subject)
+    except Exception:
+        pass
+    return "_local"
+
+
+def _tenant_runs_dir(tenant: str) -> str:
+    return RUNS_DIR if tenant == "_local" else os.path.join(RUNS_DIR, tenant)
+
+
+def _tenant_chain(tenant: str) -> AuditChain:
+    chain = _chains.get(tenant)
+    if chain is None:
+        chain = AuditChain(runs_dir=_tenant_runs_dir(tenant))
+        _chains[tenant] = chain
+    return chain
 
 
 @app.tool()
@@ -52,6 +89,7 @@ def record_action(action: str, detail: str = "", model: str = "",
     forbids the action, it is recorded as BLOCKED and you must not
     proceed with it.
     """
+    tenant = _current_tenant()
     decision = "permit"
     if _covenant:
         context = {"model": model, "tokens_total": tokens_total,
@@ -71,7 +109,7 @@ def record_action(action: str, detail: str = "", model: str = "",
     }
     if _covenant:
         record["covenant_hash"] = _covenant.hash
-    chain_hash = _chain.write(record)
+    chain_hash = _tenant_chain(tenant).write(record)
 
     if decision == "forbid":
         return (f"BLOCKED by covenant (recorded, chain_hash={chain_hash}). "
@@ -94,8 +132,8 @@ def check_covenant(action: str, category: str = "") -> str:
 
 @app.tool()
 def verify_chain() -> str:
-    """Verify the integrity of everything recorded so far this deployment."""
-    engine = ReplayEngine(runs_dir=RUNS_DIR)
+    """Verify the integrity of everything recorded so far for this tenant."""
+    engine = ReplayEngine(runs_dir=_tenant_runs_dir(_current_tenant()))
     total = engine.load()
     result = engine.verify_chain()
     if result.intact:
@@ -109,14 +147,16 @@ def verify_chain() -> str:
 def export_evidence() -> str:
     """Package all recorded actions into a signed .air-evidence ZIP."""
     from air_blackbox.export.evidence_bundle import generate_evidence_zip
-    engine = ReplayEngine(runs_dir=RUNS_DIR)
+    tenant = _current_tenant()
+    runs = _tenant_runs_dir(tenant)
+    engine = ReplayEngine(runs_dir=runs)
     engine.load()
     key = os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")
     path = generate_evidence_zip(
         chain_entries=engine._raw_records,
-        scan_results={"source": "air-blackbox MCP server",
+        scan_results={"source": "air-blackbox MCP server", "tenant": tenant,
                       "records": len(engine._raw_records)},
-        signing_key=key, output_dir=os.path.dirname(RUNS_DIR) or ".")
+        signing_key=key, output_dir=runs)
     return f"Evidence bundle written: {path} ({len(engine._raw_records)} records)"
 
 

--- a/sdk/air_blackbox/passport/__init__.py
+++ b/sdk/air_blackbox/passport/__init__.py
@@ -1,0 +1,34 @@
+"""Session passport - provable, legitimate agent activity for platforms.
+
+When an agent acts inside a logged-in session (a recruiter's LinkedIn,
+a support console, any authenticated web app) there is no API to proxy -
+the actions ARE the browser events. The passport records each action as a
+chained, covenant-governed receipt and produces a session passport: a
+signed, verifiable summary of exactly what the agent did.
+
+    from air_blackbox.passport import BrowserSession
+
+    with BrowserSession(covenant="recruiting.yaml", runs_dir="./runs") as s:
+        for profile in candidates:
+            if s.action("read_profile", target=profile.url).allowed:
+                data = driver.read(profile.url)          # your driver
+            d = s.action("send_message", target=profile.url)
+            if d.needs_approval and human_approves(profile):
+                s.approve(d)
+                driver.message(profile.url, text)
+
+    passport = s.passport()   # counts, covenant hash, chain status, verdict
+    s.export_passport()       # signed .air-evidence bundle
+
+The passport answers the platform's real question - not "was this
+automated" but "was it accountable": bounded, human-approved where it
+matters, no bulk harvesting, chain intact.
+"""
+
+from air_blackbox.passport.session import (
+    ActionDecision,
+    BrowserSession,
+    SessionPassport,
+)
+
+__all__ = ["BrowserSession", "ActionDecision", "SessionPassport"]

--- a/sdk/air_blackbox/passport/session.py
+++ b/sdk/air_blackbox/passport/session.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Optional
 
-from air_blackbox.gate.covenant import Covenant, RuleAction
+from air_blackbox.gate.covenant import Covenant
 from air_blackbox.replay.engine import ReplayEngine
 from air_blackbox.trust.chain import AuditChain
 

--- a/sdk/air_blackbox/passport/session.py
+++ b/sdk/air_blackbox/passport/session.py
@@ -1,0 +1,190 @@
+"""Browser session recording with covenant governance and a signed passport."""
+
+import os
+import uuid
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Optional
+
+from air_blackbox.gate.covenant import Covenant, RuleAction
+from air_blackbox.replay.engine import ReplayEngine
+from air_blackbox.trust.chain import AuditChain
+
+
+@dataclass
+class ActionDecision:
+    """The governance result for one attempted action."""
+    action: str
+    decision: str            # permit | require_approval | forbid
+    run_id: str
+    chain_hash: Optional[str] = None
+    approved: bool = False
+
+    @property
+    def allowed(self) -> bool:
+        """True if the agent may perform the action now (permitted, or an
+        approval-required action that has been approved)."""
+        return self.decision == "permit" or (
+            self.decision == "require_approval" and self.approved)
+
+    @property
+    def needs_approval(self) -> bool:
+        return self.decision == "require_approval" and not self.approved
+
+    @property
+    def blocked(self) -> bool:
+        return self.decision == "forbid"
+
+
+@dataclass
+class SessionPassport:
+    """A verifiable summary of everything an agent did in one session."""
+    session_id: str
+    covenant_agent: Optional[str]
+    covenant_hash: Optional[str]
+    started_at: str
+    ended_at: str
+    total_actions: int
+    action_counts: dict
+    approvals: int
+    blocked: int
+    chain_intact: bool
+    chain_verified: int
+    verdict: str                 # CLEAN | VIOLATIONS
+    violations: list = field(default_factory=list)
+
+
+class BrowserSession:
+    """Records governed browser/agent actions and issues a session passport.
+
+    Framework-agnostic: it does not drive a browser, it governs and records
+    whatever driver you use. Each `action()` call is evaluated against the
+    covenant and written into the tamper-evident chain before you act.
+    """
+
+    def __init__(self, runs_dir: str = "./passport-runs",
+                 covenant: Optional[str] = None,
+                 signing_key: Optional[str] = None):
+        self.session_id = str(uuid.uuid4())
+        self.runs_dir = os.path.join(runs_dir, self.session_id)
+        os.makedirs(self.runs_dir, exist_ok=True)
+        self._chain = AuditChain(runs_dir=self.runs_dir, signing_key=signing_key)
+        self._covenant = Covenant.from_yaml(covenant) if covenant else None
+        self._counts: Counter = Counter()
+        self._approvals = 0
+        self._blocked = 0
+        self._decisions: dict = {}
+        self._started = datetime.now(timezone.utc).isoformat()
+        self._ended: Optional[str] = None
+        self._signing_key = signing_key
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._ended = datetime.now(timezone.utc).isoformat()
+        return False
+
+    def action(self, action: str, target: str = "", **context) -> ActionDecision:
+        """Evaluate and record an attempted action. Returns the decision;
+        the caller must honor it (only act when `.allowed`)."""
+        decision = "permit"
+        if self._covenant:
+            ctx = {"target": target, "category": "browser", **context}
+            decision = self._covenant.evaluate(action, ctx).value
+
+        run_id = str(uuid.uuid4())
+        record = {
+            "run_id": run_id,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "type": "browser_action",
+            "action": action,
+            "target": str(target)[:500],
+            "session_id": self.session_id,
+            "status": "blocked" if decision == "forbid" else "success",
+            "covenant_decision": decision,
+        }
+        if self._covenant:
+            record["covenant_hash"] = self._covenant.hash
+        chain_hash = self._chain.write(record)
+
+        self._counts[action] += 1
+        if decision == "forbid":
+            self._blocked += 1
+
+        result = ActionDecision(action=action, decision=decision,
+                                run_id=run_id, chain_hash=chain_hash)
+        self._decisions[run_id] = result
+        return result
+
+    def approve(self, decision: ActionDecision, approver: str = "human") -> None:
+        """Record explicit human approval for a require_approval action.
+
+        This is the Article 14 / GDPR Art 22 moment: a human authorized a
+        candidate-affecting action, recorded into the chain as its own event.
+        """
+        decision.approved = True
+        self._approvals += 1
+        self._chain.write({
+            "run_id": str(uuid.uuid4()),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "type": "human_approval",
+            "action": "approve",
+            "approves_run_id": decision.run_id,
+            "approves_action": decision.action,
+            "approver": approver,
+            "session_id": self.session_id,
+            "status": "success",
+        })
+
+    def passport(self) -> SessionPassport:
+        """Compute the session passport from the recorded evidence."""
+        engine = ReplayEngine(runs_dir=self.runs_dir)
+        engine.load()
+        chain = engine.verify_chain(signing_key=self._signing_key)
+
+        violations = []
+        # An approval-required action that was never approved is a violation:
+        # the agent either acted without sign-off or the session is incomplete.
+        for run_id, d in self._decisions.items():
+            if d.decision == "forbid":
+                violations.append(f"blocked action attempted: {d.action}")
+            elif d.decision == "require_approval" and not d.approved:
+                violations.append(f"unapproved sensitive action: {d.action}")
+
+        verdict = "CLEAN" if (chain.intact and not violations) else "VIOLATIONS"
+        return SessionPassport(
+            session_id=self.session_id,
+            covenant_agent=self._covenant.agent if self._covenant else None,
+            covenant_hash=self._covenant.hash if self._covenant else None,
+            started_at=self._started,
+            ended_at=self._ended or datetime.now(timezone.utc).isoformat(),
+            total_actions=sum(self._counts.values()),
+            action_counts=dict(self._counts),
+            approvals=self._approvals,
+            blocked=self._blocked,
+            chain_intact=chain.intact,
+            chain_verified=chain.verified_records,
+            verdict=verdict,
+            violations=violations,
+        )
+
+    def export_passport(self, output_dir: Optional[str] = None) -> Optional[str]:
+        """Package the session into a signed .air-evidence bundle whose scan
+        payload is the passport - the document to show a platform or client."""
+        from dataclasses import asdict
+        try:
+            from air_blackbox.export.evidence_bundle import generate_evidence_zip
+        except ImportError:
+            return None
+        engine = ReplayEngine(runs_dir=self.runs_dir)
+        engine.load()
+        key = self._signing_key or os.environ.get(
+            "TRUST_SIGNING_KEY", "air-blackbox-default")
+        return generate_evidence_zip(
+            chain_entries=engine._raw_records,
+            scan_results={"session_passport": asdict(self.passport())},
+            signing_key=key,
+            output_dir=output_dir or self.runs_dir,
+        )

--- a/sdk/air_blackbox/sandbox/session.py
+++ b/sdk/air_blackbox/sandbox/session.py
@@ -41,6 +41,8 @@ class SandboxVerdict:
     evidence_path: Optional[str] = None
     lake_dir: Optional[str] = None
     config_hash: Optional[str] = None
+    covenant_hash: Optional[str] = None
+    covenant_violations: int = 0
 
 
 def _free_port() -> int:
@@ -60,7 +62,8 @@ class SandboxSession:
                  runs_dir: Optional[str] = None,
                  provider_url: str = "https://api.openai.com",
                  guardrails_config: Optional[str] = None,
-                 config_paths: Optional[list] = None):
+                 config_paths: Optional[list] = None,
+                 covenant_path: Optional[str] = None):
         if not gateway_bin and not (gateway_url and runs_dir):
             raise ValueError(
                 "need gateway_bin (managed mode) or gateway_url + runs_dir "
@@ -72,6 +75,8 @@ class SandboxSession:
         self.provider_url = provider_url
         self.guardrails_config = guardrails_config
         self.config_paths = config_paths or []
+        self.covenant_path = covenant_path
+        self._covenant = None
         self._manifest = None
         self._gateway_proc = None
         self._gateway_log = None
@@ -135,6 +140,15 @@ class SandboxSession:
     def run(self, command: list, timeout: int = 600) -> SandboxVerdict:
         os.makedirs(self.runs_dir, exist_ok=True)
         started = time.monotonic()
+
+        # Load the covenant (pre-execution policy) before the agent runs;
+        # its rules are applied to the recorded evidence at graduation, and
+        # the covenant file itself joins the attested config bundle.
+        if self.covenant_path:
+            from air_blackbox.gate.covenant import Covenant
+            self._covenant = Covenant.from_yaml(self.covenant_path)
+            if self.covenant_path not in self.config_paths:
+                self.config_paths = list(self.config_paths) + [self.covenant_path]
 
         # Attest the agent's config bundle before it runs; the gateway
         # stamps the hash into every record, binding each call to the
@@ -200,6 +214,35 @@ class SandboxSession:
         if errors:
             reasons.append(f"{errors} LLM call(s) errored")
 
+        covenant_hash = None
+        violations = 0
+        if self._covenant:
+            from air_blackbox.gate.covenant import RuleAction
+            covenant_hash = self._covenant.hash
+            examples = []
+            for raw in engine._raw_records:
+                context = {
+                    "model": raw.get("model", ""),
+                    "provider": raw.get("provider", ""),
+                    "endpoint": raw.get("endpoint", ""),
+                    "status": raw.get("status", ""),
+                    "tokens_total": (raw.get("tokens") or {}).get("total", 0),
+                    "category": "llm",
+                }
+                decision = self._covenant.evaluate("llm_call", context)
+                # The sandbox is unattended, so require_approval cannot be
+                # satisfied and counts as a violation like forbid.
+                if decision != RuleAction.PERMIT:
+                    violations += 1
+                    if len(examples) < 3:
+                        examples.append(
+                            f"{raw.get('run_id', '?')[:8]} ({context['model']}, "
+                            f"{context['tokens_total']} tokens): {decision.value}")
+            if violations:
+                reasons.append(
+                    f"{violations} call(s) violated covenant '{self._covenant.agent}': "
+                    + "; ".join(examples))
+
         config_hash = None
         if self._manifest:
             from air_blackbox.attest import check_manifest
@@ -222,6 +265,8 @@ class SandboxSession:
             duration_seconds=round(duration, 2),
             sandbox_dir=self.sandbox_dir,
             config_hash=config_hash,
+            covenant_hash=covenant_hash,
+            covenant_violations=violations,
         )
 
         verdict.lake_dir = self._export_lake()

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -62,10 +62,10 @@ def test_build_auth_introspection_mode(monkeypatch):
 
 
 def test_tenant_id_is_filesystem_safe():
-    from air_blackbox.mcp_server import _safe_tenant
-    assert _safe_tenant("../etc/passwd") == "___etc_passwd"
-    assert "/" not in _safe_tenant("a/b/c")
-    assert _safe_tenant("normal-id_1") == "normal-id_1"
+    import air_blackbox.mcp_server as srv
+    assert srv._safe_tenant("../etc/passwd") == "___etc_passwd"
+    assert "/" not in srv._safe_tenant("a/b/c")
+    assert srv._safe_tenant("normal-id_1") == "normal-id_1"
 
 
 def test_tenant_chains_are_isolated(tmp_path, monkeypatch):

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -1,0 +1,87 @@
+"""Tests for MCP OAuth token verification and tenant isolation."""
+
+import os
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from air_blackbox.mcp_auth import (  # noqa: E402
+    IntrospectionTokenVerifier,
+    StaticTokenVerifier,
+    build_auth,
+)
+
+
+async def _verify(verifier, token):
+    return await verifier.verify_token(token)
+
+
+def test_static_verifier_valid_token():
+    import asyncio
+    v = StaticTokenVerifier("secret123:recruiter-a:read|write")
+    tok = asyncio.run(_verify(v, "secret123"))
+    assert tok is not None
+    assert tok.subject == "recruiter-a"
+    assert tok.scopes == ["read", "write"]
+
+
+def test_static_verifier_rejects_unknown():
+    import asyncio
+    v = StaticTokenVerifier("secret123:recruiter-a")
+    assert asyncio.run(_verify(v, "wrong")) is None
+
+
+def test_static_verifier_multiple_tenants():
+    import asyncio
+    v = StaticTokenVerifier("t1:alice,t2:bob")
+    assert asyncio.run(_verify(v, "t1")).subject == "alice"
+    assert asyncio.run(_verify(v, "t2")).subject == "bob"
+
+
+def test_build_auth_disabled_without_env(monkeypatch):
+    monkeypatch.delenv("AIR_MCP_INTROSPECTION_URL", raising=False)
+    monkeypatch.delenv("AIR_MCP_TOKENS", raising=False)
+    verifier, settings = build_auth()
+    assert verifier is None and settings is None
+
+
+def test_build_auth_static_mode(monkeypatch):
+    monkeypatch.delenv("AIR_MCP_INTROSPECTION_URL", raising=False)
+    monkeypatch.setenv("AIR_MCP_TOKENS", "k:tenant1")
+    verifier, settings = build_auth()
+    assert isinstance(verifier, StaticTokenVerifier)
+    assert settings is not None
+
+
+def test_build_auth_introspection_mode(monkeypatch):
+    monkeypatch.setenv("AIR_MCP_INTROSPECTION_URL", "https://idp.example.com/introspect")
+    verifier, settings = build_auth()
+    assert isinstance(verifier, IntrospectionTokenVerifier)
+    assert settings is not None
+
+
+def test_tenant_id_is_filesystem_safe():
+    from air_blackbox.mcp_server import _safe_tenant
+    assert _safe_tenant("../etc/passwd") == "___etc_passwd"
+    assert "/" not in _safe_tenant("a/b/c")
+    assert _safe_tenant("normal-id_1") == "normal-id_1"
+
+
+def test_tenant_chains_are_isolated(tmp_path, monkeypatch):
+    # Two tenants writing through the server land in separate runs dirs and
+    # separate chains.
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    a = srv._tenant_chain("alice")
+    b = srv._tenant_chain("bob")
+    a.write({"run_id": "a1", "action": "read_profile",
+             "timestamp": "2026-07-16T00:00:00Z"})
+    b.write({"run_id": "b1", "action": "read_profile",
+             "timestamp": "2026-07-16T00:00:00Z"})
+
+    assert os.path.isfile(os.path.join(tmp_path, "alice", "a1.air.json"))
+    assert os.path.isfile(os.path.join(tmp_path, "bob", "b1.air.json"))
+    assert not os.path.isfile(os.path.join(tmp_path, "alice", "b1.air.json"))

--- a/sdk/tests/test_passport.py
+++ b/sdk/tests/test_passport.py
@@ -1,0 +1,86 @@
+"""Tests for the session passport (accountable browser-agent activity)."""
+
+import os
+
+from air_blackbox.passport import BrowserSession
+
+COVENANT = os.path.join(
+    os.path.dirname(__file__), "..", "air_blackbox", "gate", "examples",
+    "linkedin-sourcing.covenant.yaml")
+
+
+def _session(tmp_path, key="passport-key"):
+    return BrowserSession(runs_dir=str(tmp_path), covenant=COVENANT,
+                          signing_key=key)
+
+
+def test_permitted_actions_allowed(tmp_path):
+    with _session(tmp_path) as s:
+        d = s.action("read_profile", target="https://linkedin.com/in/alice")
+        assert d.allowed and not d.needs_approval
+        assert d.decision == "permit"
+
+
+def test_sensitive_action_needs_approval(tmp_path):
+    with _session(tmp_path) as s:
+        d = s.action("send_message", target="https://linkedin.com/in/alice")
+        assert d.needs_approval and not d.allowed
+        s.approve(d)
+        assert d.allowed
+
+
+def test_forbidden_action_blocked(tmp_path):
+    with _session(tmp_path) as s:
+        d = s.action("scrape_search_page")
+        assert d.blocked and not d.allowed
+
+
+def test_clean_session_passport(tmp_path):
+    with _session(tmp_path) as s:
+        for i in range(5):
+            assert s.action("read_profile", target=f"/in/c{i}").allowed
+        d = s.action("send_message", target="/in/c0")
+        s.approve(d)
+    p = s.passport()
+    assert p.verdict == "CLEAN"
+    assert p.chain_intact
+    assert p.action_counts["read_profile"] == 5
+    assert p.approvals == 1
+    assert p.total_actions == 6
+    assert not p.violations
+
+
+def test_unapproved_sensitive_action_is_a_violation(tmp_path):
+    with _session(tmp_path) as s:
+        s.action("read_profile", target="/in/a")
+        s.action("send_message", target="/in/a")   # never approved
+    p = s.passport()
+    assert p.verdict == "VIOLATIONS"
+    assert any("unapproved" in v for v in p.violations)
+
+
+def test_blocked_action_is_a_violation(tmp_path):
+    with _session(tmp_path) as s:
+        s.action("harvest_emails")
+    p = s.passport()
+    assert p.verdict == "VIOLATIONS"
+    assert p.blocked == 1
+    assert any("blocked" in v for v in p.violations)
+
+
+def test_passport_export_produces_bundle(tmp_path):
+    with _session(tmp_path) as s:
+        d = s.action("send_message", target="/in/a")
+        s.approve(d)
+    path = s.export_passport()
+    assert path and os.path.exists(path)
+
+
+def test_chain_survives_and_verifies(tmp_path):
+    with _session(tmp_path) as s:
+        for i in range(3):
+            s.action("navigate", target=f"/page/{i}")
+    p = s.passport()
+    # Every action recorded is chained and verifies with the session key.
+    assert p.chain_intact
+    assert p.chain_verified == 3

--- a/sdk/tests/test_sandbox.py
+++ b/sdk/tests/test_sandbox.py
@@ -87,3 +87,55 @@ def test_requires_gateway_config():
     import pytest
     with pytest.raises(ValueError):
         SandboxSession(sandbox_dir="/tmp/x")
+
+
+COVENANT = """
+agent: test-agent
+version: "1.0"
+rules:
+  - permit: llm_call
+  - forbid: llm_call
+    when: "model == gpt-5"
+  - forbid: llm_call
+    when: "tokens_total > 50"
+"""
+
+
+def _run_with_covenant(model="gpt-4", tokens=10):
+    with tempfile.TemporaryDirectory() as d:
+        runs = os.path.join(d, "runs")
+        os.makedirs(runs)
+        with open(os.path.join(runs, ".air-signing-key"), "w") as f:
+            f.write("sandbox-test-key\n")
+        cov_path = os.path.join(d, "test.covenant.yaml")
+        with open(cov_path, "w") as f:
+            f.write(COVENANT)
+        session = SandboxSession(
+            sandbox_dir=d, gateway_url="http://unused:1", runs_dir=runs,
+            covenant_path=cov_path)
+        agent = AGENT.format(sdk_path=os.path.abspath(SDK_PATH), runs_dir=runs)
+        # Patch the model/token values the fake agent records.
+        agent = agent.replace('"model": "gpt-4"', f'"model": "{model}"')
+        agent = agent.replace('"total": 10', f'"total": {tokens}')
+        verdict = session.run([sys.executable, "-c", agent, "2", "0"], timeout=60)
+        return verdict
+
+
+def test_covenant_compliant_run_graduates():
+    verdict = _run_with_covenant(model="gpt-4", tokens=10)
+    assert verdict.passed
+    assert verdict.covenant_hash
+    assert verdict.covenant_violations == 0
+
+
+def test_covenant_forbidden_model_fails():
+    verdict = _run_with_covenant(model="gpt-5", tokens=10)
+    assert not verdict.passed
+    assert verdict.covenant_violations == 2
+    assert any("covenant" in r for r in verdict.reasons)
+
+
+def test_covenant_token_budget_fails():
+    verdict = _run_with_covenant(model="gpt-4", tokens=99)
+    assert not verdict.passed
+    assert verdict.covenant_violations == 2


### PR DESCRIPTION
## What does this PR do?
Extends the trust layer into agent **governance** — declare what an agent may do, record what it did, prove the two match — across three surfaces: the compliance sandbox, Claude itself (MCP), and logged-in browser sessions (6 commits).

**Covenant enforcement at graduation** — the compliance sandbox now accepts a Gate covenant (`--covenant`). The covenant file is auto-attested into the config bundle, and at graduation every recorded LLM call is evaluated against the policy; `forbid` (and `require_approval`, which an unattended sandbox cannot satisfy) count as violations and fail graduation, with the covenant hash recorded in the verdict.

**ADM-safe recruiting covenant example** — maps automated-decision-making exposure in hiring automation (GDPR Art 22, EU AI Act Annex III, NYC LL144, Colorado SB 24-205) to covenant rules.

**Governance MCP server** — `air-blackbox-mcp` connects to Claude (Desktop or claude.ai). `record_action` writes each agent action into the tamper-evident chain, covenant-evaluated first (forbidden → recorded as blocked; approval-required → instructs Claude to get human sign-off); `check_covenant`, `verify_chain`, and `export_evidence` complete the loop. Removes the empty root `mcp/` stub that shadowed the MCP SDK package.

**Remote HTTP transport + deploy config** — `AIR_MCP_TRANSPORT=http` serves streamable-HTTP MCP on `/mcp` for claude.ai custom connectors; container build and Fly.io config to tether to `mcp.airblackbox.ai`.

**OAuth resource-server auth + per-tenant isolation** — verifies OAuth 2.1 bearer tokens (RFC 7662 introspection against an external IdP, or static per-tenant tokens for self-hosting); advertises `/.well-known/oauth-protected-resource`; no token → 401. The verified token subject keys a per-tenant audit chain, so each connected user's records and evidence are fully isolated.

**Session passport** — when an agent acts inside a logged-in session (a recruiter's LinkedIn, a support console) there is no API to proxy; the actions are the browser events. `BrowserSession` records each action as a chained, covenant-governed receipt and issues a **session passport**: a signed, verifiable summary of exactly what the agent did — bounded, human-approved where it matters, no bulk harvesting, chain intact. Framework-agnostic (governs any driver). Ships a LinkedIn sourcing covenant example. This is the "prove legitimate agent activity to the platform" primitive.

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] New compliance check
- [ ] Refactor / code quality
- [x] Trust layer integration

## EU AI Act articles affected
Article 14 (human oversight: `require_approval` enforcement in sandbox, MCP, and passport), Article 12 (record-keeping: MCP + browser action chains, per-tenant evidence), Article 9 (risk management: pre-deployment covenant gate). Also GDPR Art 22 and Annex III high-risk employment via the recruiting and sourcing covenants.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (132 Python tests; Go suite unchanged)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (all features additive and opt-in; record format unchanged)

## Additional notes
Proven live end-to-end in-session: covenant graduation paths; MCP record/block/verify/export; HTTP MCP handshake; OAuth 401-without-token / 200-with-bearer / per-subject isolation / discovery endpoint; and a simulated LinkedIn sourcing session producing a passport (7 profiles viewed, 3 human-approved messages, 1 blocked scrape attempt flagged, chain intact over all 17 records).

Deploying to `mcp.airblackbox.ai` still requires wiring an IdP (or minting static tokens) and `fly deploy` + DNS — see `deploy/mcp/README.md`. Recommend **squash merge**, as with #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn