### PR TITLE
Zero-code governance in Claude: MCP UX, field-test hardening, and a reproducible demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,12 @@ gets recorded, policy-gated, and provable - zero code for the person using
 it. Field-tested end to end: covenant-gated rejections stop for explicit
 human approval, and the audit trail exports as a signed, self-verifying
 bundle. Full setup + scripted demo (with fictional candidates):
-[docs/guides/governed-recruiting-demo.md](docs/guides/governed-recruiting-demo.md)
+[docs/guides/governed-recruiting-demo.md](docs/guides/governed-recruiting-demo.md).
+Reproduce the whole flow in one command — screen, gate, approve, verify,
+export, and a live tamper test — with
+[`python demo/governed_screening_demo.py`](demo/governed_screening_demo.py),
+or record the Claude Desktop version from
+[demo/desktop-demo-shotlist.md](demo/desktop-demo-shotlist.md).
 
 ## Deploy on Kubernetes
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ a Parquet lake dataset, and a signed `.air-evidence` bundle an approver can
 verify independently - the graduation certificate. Agents that bypass the
 gateway fail: no records, no graduation.
 
+## Governance inside Claude (preview)
+
+Connect the AIR MCP server to Claude Desktop and every screening decision
+gets recorded, policy-gated, and provable - zero code for the person using
+it. Field-tested end to end: covenant-gated rejections stop for explicit
+human approval, and the audit trail exports as a signed, self-verifying
+bundle. Full setup + scripted demo (with fictional candidates):
+[docs/guides/governed-recruiting-demo.md](docs/guides/governed-recruiting-demo.md)
+
 ## Deploy on Kubernetes
 
 ```bash

--- a/bench/chainstress/stress.py
+++ b/bench/chainstress/stress.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Stress test the AIR gateway audit chain under concurrent load."""
+import concurrent.futures as cf
+import json
+import os
+import sys
+import time
+import urllib.request
+
+GATEWAY = "http://127.0.0.1:8080"
+RUNS = sys.argv[1]
+N = int(sys.argv[2]) if len(sys.argv) > 2 else 500
+CONCURRENCY = int(sys.argv[3]) if len(sys.argv) > 3 else 50
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "sdk"))
+from air_blackbox.replay.engine import ReplayEngine
+
+
+def call(i):
+    body = json.dumps({"model": "gpt-4", "messages": [
+        {"role": "user", "content": f"screen candidate #{i}"}]}).encode()
+    req = urllib.request.Request(f"{GATEWAY}/v1/chat/completions", data=body,
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.monotonic()
+    with urllib.request.urlopen(req, timeout=30) as r:
+        r.read()
+    return (time.monotonic() - t0) * 1000
+
+
+print(f"Firing {N} requests at concurrency {CONCURRENCY}...")
+t0 = time.monotonic()
+lat = []
+with cf.ThreadPoolExecutor(max_workers=CONCURRENCY) as ex:
+    for ms in ex.map(call, range(N)):
+        lat.append(ms)
+wall = time.monotonic() - t0
+
+lat.sort()
+print(f"  {N} requests in {wall:.2f}s = {N/wall:.0f} req/s")
+print(f"  latency p50={lat[len(lat)//2]:.1f}ms p95={lat[int(len(lat)*0.95)]:.1f}ms "
+      f"p99={lat[int(len(lat)*0.99)]:.1f}ms max={lat[-1]:.1f}ms")
+
+# Records land asynchronously; wait for the background writers to drain.
+print("Waiting for async record writes to settle...")
+for _ in range(30):
+    time.sleep(1)
+    n = len([f for f in os.listdir(RUNS) if f.endswith(".air.json")])
+    if n >= N:
+        break
+print(f"  {n}/{N} records on disk")
+
+print("Verifying the full chain...")
+t0 = time.monotonic()
+engine = ReplayEngine(runs_dir=RUNS)
+total = engine.load()
+result = engine.verify_chain()
+vt = time.monotonic() - t0
+print(f"  {total} records, chain {'INTACT' if result.intact else 'BROKEN'}, "
+      f"{result.verified_records} verified in {vt:.2f}s")
+
+# Check sequence completeness: no gaps, no dupes.
+seqs = sorted(r.get("chain_seq", 0) for r in engine._raw_records)
+expected = list(range(1, total + 1))
+gaps = set(expected) - set(seqs)
+dupes = len(seqs) - len(set(seqs))
+print(f"  chain_seq: min={seqs[0]} max={seqs[-1]} gaps={len(gaps)} dupes={dupes}")
+
+ok = (result.intact and result.verified_records == total
+      and not gaps and not dupes and total == N)
+print("RESULT:", "PASS" if ok else "FAIL")
+sys.exit(0 if ok else 1)

--- a/demo/desktop-demo-shotlist.md
+++ b/demo/desktop-demo-shotlist.md
@@ -1,0 +1,85 @@
+# Claude Desktop Demo — Shot List (for screen recording)
+
+The "what it feels like" companion to the terminal proof
+(`demo/governed_screening_demo.py`). This is the video that sells it to
+recruiters: a human types plain English, and governance visibly happens.
+
+**Never use real candidates.** Use the fictional pool below.
+
+---
+
+## Before you hit record
+
+```bash
+cd airblackbox && git pull
+pip3 install -e ".[mcp,gate]"
+mv ~/.air-blackbox/runs ~/.air-blackbox/runs-$(date +%s) 2>/dev/null; true   # clean slate
+```
+
+- Confirm the connector: Claude Desktop → Settings → Developer → `air-blackbox` shows **running** (green), not an error.
+- Open a **new chat**. Zoom the window so tool-call cards are legible on playback.
+- Have the fictional candidates + role (below) in a scratch file to paste.
+- Optional but powerful: record the **"before"** first — same script with the connector toggled OFF — so you have the "I haven't been keeping one" moment to cut against the "after."
+
+---
+
+## The shots
+
+**Shot 1 — Prove it's wired (5 sec).**
+Type: `What air-blackbox tools do you have?`
+Capture: Claude names the five tools. Establishes the connector is live.
+
+**Shot 2 — The guardrail nobody games (15 sec).** *(the hook)*
+Type: `Check the covenant — can I have you guess a candidate's ethnicity from their name?`
+Capture: the `check_covenant` card → **forbid**. Claude explains it won't, and that the policy forbids it too. This is the "it says no to the wrong thing" beat.
+
+**Shot 3 — Screen the pool (30 sec).**
+Paste the role, then the three candidates (below). Type: `Screen and rank these three against the role, and log each decision.`
+Capture: `log_screening_decision` cards appearing *before* Claude's written ranking. Point out in voiceover: "the record is written before it tells me the answer."
+
+**Shot 4 — The money moment (20 sec).** *(the payoff)*
+Type: `Eliminate the weakest candidate from the group.`
+Capture: the `require_approval` result and Claude **stopping to ask for your explicit approval** instead of just doing it. Say yes on camera. Voiceover: "That pause is the law — a human has to sign off on a rejection. It's enforced, not suggested."
+
+**Shot 5 — The receipts (15 sec).**
+Type: `Give me my audit trail, and export the evidence.`
+Capture: `verify_chain` → **CHAIN INTACT**, then the signed `.air-evidence` path with **"chain fully verified at export time."**
+
+**Shot 6 — Proof, not notes (20 sec).** *(the closer — cut to terminal)*
+```bash
+air-blackbox replay --runs-dir ~/.air-blackbox/runs --verify      # ✅ INTACT
+# open any file in ~/.air-blackbox/runs, change one character, save
+air-blackbox replay --runs-dir ~/.air-blackbox/runs --verify      # ❌ BROKEN at that record
+```
+Voiceover: "Change one character and the whole thing flags exactly where. That's the difference between a log and evidence."
+
+---
+
+## Demo materials (fictional — paste verbatim)
+
+**Role:**
+> Senior Backend Engineer, Meridian Logistics (fictional). Must-haves: 5+ yrs
+> backend; high-throughput distributed systems (queues/streaming at scale);
+> Python or Go in production; operated systems >1M events/day. Remote OK, US
+> hours. Band $170–200k.
+
+**Priya Raghavan** (fictional) — Python, Kafka, event pipelines, 7 yrs. Built
+ingestion at ~40M events/day; led batch→streaming migration; on-call lead.
+Open to roles.
+
+**Marcus Bell** (fictional) — C#/.NET, AWS serverless, integrations, 12 yrs.
+Deep integrations, dbt/Snowflake; no streaming-at-scale. No availability
+signal.
+
+**Dana Okafor** (fictional) — Go, distributed KV stores, 6 yrs. Profile note:
+"I am not job searching. Applications are being submitted using my name — if
+you receive one, it is not from me."
+
+---
+
+## Editing notes
+
+- Total runtime target: **90 seconds.** Shots 2 and 4 are the keepers; everything else is connective tissue.
+- Open on Shot 4's approval pause as a 3-second teaser, then cut to the start — lead with the payoff.
+- Keep the fictional-candidate disclaimer on screen for one beat; it signals you understand the exact risk your product addresses.
+- Do NOT show real `~/.air-blackbox/runs` contents from prior real sessions — they may contain real candidate PII.

--- a/demo/governed_screening_demo.py
+++ b/demo/governed_screening_demo.py
@@ -86,7 +86,10 @@ def main():
     call("export_evidence()", m.export_evidence())
 
     beat("[5] Independent proof — the human-readable chain")
-    rows = [json.load(open(p)) for p in glob.glob(os.path.join(runs, "*.air.json"))]
+    rows = []
+    for p in glob.glob(os.path.join(runs, "*.air.json")):
+        with open(p) as f:
+            rows.append(json.load(f))
     rows.sort(key=lambda r: r.get("chain_seq", 0))
     print(f"    {'seq':>3}  {'action':<28} {'decision':<16} detail")
     print("    " + "-" * 78)
@@ -98,10 +101,12 @@ def main():
     beat("[6] TAMPER TEST — falsify one stored record, then re-verify")
     from air_blackbox.replay.engine import ReplayEngine
     for p in glob.glob(os.path.join(runs, "*.air.json")):
-        r = json.load(open(p))
+        with open(p) as f:
+            r = json.load(f)
         if r.get("action") == "reject_candidate":
             r["detail"] = "APPROVED ON MERIT - top candidate"   # the forgery
-            json.dump(r, open(p, "w"))
+            with open(p, "w") as f:
+                json.dump(r, f)
             print(f"    {RED}✗ tampered record seq {r.get('chain_seq')}: "
                   f"rewrote the rejection rationale{RESET}")
             break

--- a/demo/governed_screening_demo.py
+++ b/demo/governed_screening_demo.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""AIR Blackbox — governed candidate screening, live against the real engine.
+
+Runs the exact tool sequence Claude Desktop calls, with fictional candidates,
+and prints every result: covenant enforcement, logged decisions, the human
+approval gate, chain verification, a signed evidence export, and a live tamper
+test that breaks the chain at the exact record.
+
+    pip install air-blackbox[mcp,gate]
+    python demo/governed_screening_demo.py
+
+Nothing here is mocked. The candidates are fictional; never demo with real
+people's profiles.
+"""
+
+import glob
+import json
+import os
+import tempfile
+
+BOLD, DIM, GREEN, RED, RESET = "\033[1m", "\033[2m", "\033[32m", "\033[31m", "\033[0m"
+
+
+def beat(title):
+    print(f"\n{BOLD}{title}{RESET}")
+
+
+def call(label, out):
+    print(f"  {DIM}▸ {label}{RESET}")
+    print("    " + out.replace("\n", "\n    "))
+
+
+def main():
+    # Isolated runs dir + the shipped recruiting covenant, so the demo is
+    # reproducible and never touches a real store.
+    runs = tempfile.mkdtemp(prefix="air-demo-")
+    os.environ["AIR_RUNS_DIR"] = runs
+    here = os.path.dirname(os.path.abspath(__file__))
+    os.environ["AIR_COVENANT"] = os.path.join(
+        here, "..", "sdk", "air_blackbox", "gate", "examples",
+        "recruiting-screener.covenant.yaml")
+
+    from air_blackbox import mcp_server as m
+
+    print("=" * 72)
+    print("  GOVERNED CANDIDATE SCREENING  —  real engine, fictional candidates")
+    print("  Role: Senior Backend Engineer (high-throughput distributed systems)")
+    print("=" * 72)
+
+    beat("[0] Prove the policy is loaded and actually governing")
+    call('check_covenant("infer_protected_attributes")',
+         m.check_covenant("infer_protected_attributes"))
+
+    beat("[1] Screen & rank — logged BEFORE the conclusion is stated")
+    call('log_screening_decision("Priya Raghavan", "rank", ...)',
+         m.log_screening_decision(
+             "Priya Raghavan", "rank",
+             "40M events/day Kafka ingestion, batch->streaming migration, "
+             "on-call lead — direct match"))
+    print(f"    {DIM}>>> recruiter: \"approve that ranking\"{RESET}")
+    call('record_action("human_approval", ...)',
+         m.record_action("human_approval",
+                         detail="rank Priya Raghavan approved by user",
+                         category="screening"))
+
+    beat("[2] A forbidden action is attempted — blocked AND recorded")
+    call('record_action("infer_protected_attributes", ...)',
+         m.record_action("infer_protected_attributes",
+                         detail="guess ethnicity from candidate name"))
+
+    beat("[3] 'Eliminate the weakest' — the rejection stops for human approval")
+    call('check_covenant("reject_candidate")', m.check_covenant("reject_candidate"))
+    call('log_screening_decision("Dana Okafor", "reject", ...)',
+         m.log_screening_decision(
+             "Dana Okafor", "reject",
+             "Provenance only: profile carries an impersonation notice; "
+             "NOT a merit judgment"))
+    print(f"    {DIM}>>> recruiter: \"yes, approve\"{RESET}")
+    call('record_action("human_approval", ...)',
+         m.record_action("human_approval",
+                         detail="reject_candidate for Dana Okafor approved by user",
+                         category="screening"))
+
+    beat("[4] The receipts — verify and export")
+    call("verify_chain()", m.verify_chain())
+    call("export_evidence()", m.export_evidence())
+
+    beat("[5] Independent proof — the human-readable chain")
+    rows = [json.load(open(p)) for p in glob.glob(os.path.join(runs, "*.air.json"))]
+    rows.sort(key=lambda r: r.get("chain_seq", 0))
+    print(f"    {'seq':>3}  {'action':<28} {'decision':<16} detail")
+    print("    " + "-" * 78)
+    for r in rows:
+        detail = (r.get("detail") or "")[:30]
+        print(f"    {r.get('chain_seq'):>3}  {r.get('action', ''):<28} "
+              f"{r.get('covenant_decision', ''):<16} {detail}")
+
+    beat("[6] TAMPER TEST — falsify one stored record, then re-verify")
+    from air_blackbox.replay.engine import ReplayEngine
+    for p in glob.glob(os.path.join(runs, "*.air.json")):
+        r = json.load(open(p))
+        if r.get("action") == "reject_candidate":
+            r["detail"] = "APPROVED ON MERIT - top candidate"   # the forgery
+            json.dump(r, open(p, "w"))
+            print(f"    {RED}✗ tampered record seq {r.get('chain_seq')}: "
+                  f"rewrote the rejection rationale{RESET}")
+            break
+    eng = ReplayEngine(runs_dir=runs)
+    eng.load()
+    v = eng.verify_chain()
+    print(f"    {RED}✗ verify_chain now: CHAIN BROKEN at record "
+          f"{v.first_break_at} — {v.verified_records} verified before the "
+          f"break{RESET}")
+    print(f"\n  {GREEN}The forgery is caught at the exact record. "
+          f"It's not notes — it's proof.{RESET}\n")
+    print(f"  {DIM}Records were written to {runs}{RESET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,142 @@
+# AIR Blackbox — End-to-End Demo & Operator Guide
+
+A worked recruiting scenario that exercises the whole product: a governed
+AI screener, a tamper-evident audit chain, a queryable lake, a covenant-
+governed browser session, and a signed evidence bundle. Every command below
+was run against the real gateway; the numbers in "Stress test" are measured,
+not estimated.
+
+---
+
+## 0. Prerequisites
+
+```bash
+# Python SDK + optional extras used here
+pip install -e ".[lake]"          # from the repo root (adds pyarrow)
+
+# Build the Go gateway and the mock provider (no real API key needed to demo)
+go build -o /tmp/air-gateway ./cmd/gateway
+go build -o /tmp/air-mockllm ./bench/mockllm
+```
+
+---
+
+## 1. Start the gateway
+
+The gateway is an OpenAI-compatible reverse proxy. Point it at any provider;
+here we use the bundled mock so the demo is self-contained and free.
+
+```bash
+/tmp/air-mockllm &                       # fake provider on :9100
+
+LISTEN_ADDR=:8080 \
+PROVIDER_URL=http://127.0.0.1:9100 \
+RUNS_DIR=./demo-runs \
+/tmp/air-gateway &
+```
+
+No `TRUST_SIGNING_KEY` is set, so the gateway generates a random key and
+writes it to `demo-runs/.air-signing-key` (mode 0600). Verification tooling
+auto-discovers it — zero key handling. In production, set `TRUST_SIGNING_KEY`
+from your secret store instead.
+
+**Point your agent at it:** change one line in your code.
+
+```python
+client = OpenAI(base_url="http://localhost:8080/v1")   # that's the whole change
+```
+
+---
+
+## 2. Run the scenario
+
+```bash
+python examples/recruiting_demo.py --gateway http://127.0.0.1:8080 --runs ./demo-runs
+```
+
+What it does, step by step:
+
+| Step | What happens | What you get |
+|------|--------------|--------------|
+| 1 | 5 candidates screened via `/v1/chat/completions` | 5 signed `.air.json` records, HMAC-chained |
+| 2 | `ReplayEngine.verify_chain()` | `chain INTACT, 5 records verified` |
+| 3 | `lake.export_records` + `verify_lake` | Parquet dataset, verified in-place |
+| 4 | Outreach as a `BrowserSession` under a covenant | session passport (read permitted, sends human-approved, scrape **blocked**) |
+| 5 | `export_passport()` | signed `.air-evidence` ZIP for an auditor/client |
+
+Step 4's verdict is `VIOLATIONS` **on purpose** — the demo agent attempts a
+`scrape_search_page` and the covenant blocks it. That blocked attempt is
+itself recorded: the governance catching overreach is the point.
+
+---
+
+## 3. Inspect and prove
+
+```bash
+# Human-readable timeline of every screening decision
+air-blackbox replay --runs-dir ./demo-runs
+
+# Prove nothing was altered (auto-discovers the signing key)
+air-blackbox replay --runs-dir ./demo-runs --verify
+#   ✅ CHAIN INTACT - 5 records verified. No tampering detected.
+
+# Query the audit trail as data
+air-blackbox lake export --runs-dir ./demo-runs -o ./demo-lake
+air-blackbox lake verify -o ./demo-lake
+```
+
+Try tampering to see detection fire: edit any `model` field in a
+`demo-runs/*.air.json`, then re-run `--verify`. It reports the exact record
+that broke and refuses to certify the chain.
+
+---
+
+## 4. Governance surfaces
+
+The same covenant model, chain, and evidence bundle work in three places:
+
+- **Sandbox** (pre-deployment): `air-blackbox sandbox-run --covenant policy.yaml --gateway-bin /tmp/air-gateway -- python your_agent.py` — the agent graduates only if the recorded evidence obeys the covenant.
+- **Claude-native** (MCP): `air-blackbox-mcp` — connect it to Claude Desktop or, via `deploy/mcp/`, to claude.ai. `record_action` governs and records each step Claude takes.
+- **Browser session** (logged-in apps): `air_blackbox.passport.BrowserSession` — governs any driver, issues a session passport.
+
+---
+
+## 5. Stress test (measured)
+
+```bash
+# with the gateway running against RUNS_DIR=./stress-runs
+python bench/chainstress/stress.py ./stress-runs 2000 100   # N=2000, concurrency=100
+```
+
+Results on a single node, recording enabled, against the mock provider:
+
+| Metric | 500 @ 50 | 2000 @ 100 |
+|--------|---------:|-----------:|
+| Throughput | 1,538 req/s | 1,639 req/s |
+| Latency p50 / p99 | 17.6 / 54.6 ms | 36.7 / 142.5 ms |
+| Records persisted | 500 / 500 | 2000 / 2000 |
+| Chain | INTACT, 500 verified | INTACT, 2000 verified |
+| `chain_seq` gaps / dupes | 0 / 0 | 0 / 0 |
+| Full-chain verify time | 0.02 s | 0.07 s |
+
+The gaps/dupes=0 line is the important one: records are written
+asynchronously off the request path, yet under 100-way concurrency the
+chain sequence is complete and every link verifies. **Tamper detection at
+scale:** altering the record at `chain_seq=1000` in the 2000-record chain is
+caught precisely — 999 verified, break at index 999.
+
+Reproduce: `python bench/chainstress/stress.py <runs_dir> <N> <concurrency>`.
+
+---
+
+## 6. Production checklist
+
+- Set `TRUST_SIGNING_KEY` from a secret store; back up the keyfile if you let
+  the gateway generate one. Whoever holds the key can produce valid chains —
+  treat it like a signing secret.
+- Records contain prompt/PII context: keep the runs dir, lake, and bundles
+  in-region and encrypted at rest; archive evidence bundles to WORM storage
+  (S3 Object Lock) for retention.
+- One chain per gateway replica. For HA, keep per-replica runs dirs separate
+  and verify each independently (see `deploy/HA.md`).
+- Enable OAuth on the MCP server before exposing it (`deploy/mcp/README.md`).

--- a/docs/guides/governed-recruiting-demo.md
+++ b/docs/guides/governed-recruiting-demo.md
@@ -1,0 +1,187 @@
+# Governed Recruiting with Claude — Setup & Demo Guide
+
+AI screening a candidate pool with every decision recorded into a
+tamper-evident chain, human approval enforced on rejections, and a signed
+evidence bundle at the end. Zero code for the person running it.
+
+This guide is the full step-by-step process (Part 1), a scripted demo with
+expected outputs at every beat (Part 2), independent verification (Part 3),
+and every failure mode we hit in live field testing (Part 4).
+
+> **Never demo with real people's profiles.** The candidate materials below
+> are fictional. Screening real people creates real ADM records about them.
+
+---
+
+## Part 1 — Setup (one time, ~5 minutes)
+
+**1. Install** (requires Python 3.10+):
+
+```bash
+git clone https://github.com/airblackbox/airblackbox.git
+cd airblackbox
+pip3 install -e ".[mcp,gate]"
+which air-blackbox-mcp        # note this absolute path
+pwd                           # note this too
+```
+
+**2. Connect to Claude Desktop.** Settings → Developer → Edit Config, add:
+
+```json
+{
+  "mcpServers": {
+    "air-blackbox": {
+      "command": "<output of `which air-blackbox-mcp`>",
+      "env": {
+        "AIR_COVENANT": "<output of pwd>/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
+      }
+    }
+  }
+}
+```
+
+Both paths must be **absolute** — Claude Desktop does not inherit your
+shell's PATH. Then quit Claude Desktop completely (Cmd+Q) and relaunch.
+
+**3. Truth test.** New chat: *"What air-blackbox tools do you have?"*
+You must see five tools named: `record_action`, `log_screening_decision`,
+`check_covenant`, `verify_chain`, `export_evidence`. If not → Part 4.
+
+**4. Clean slate for the demo.** Records accumulate in
+`~/.air-blackbox/runs/`. Before a demo, archive any test debris:
+
+```bash
+mv ~/.air-blackbox/runs ~/.air-blackbox/runs-$(date +%s) 2>/dev/null; true
+```
+
+---
+
+## Part 2 — The demo script
+
+### Demo materials (fictional)
+
+**The role** — paste when asked for a JD:
+
+> Senior Backend Engineer, Meridian Logistics (fictional). Must-haves:
+> 5+ years backend, high-throughput distributed systems (queues/streaming
+> at scale), Python or Go in production, operated systems with >1M
+> events/day. Nice-to-have: event-sourcing, on-call ownership. Remote OK,
+> US hours. Band: $170–200k.
+
+**Candidate A — Priya Raghavan (fictional)**
+
+> Senior Backend Engineer — Python, Kafka, event pipelines. 7 yrs.
+> Currently: staff-adjacent IC at a logistics SaaS; built ingestion
+> handling ~40M events/day across 12 partners; led move from cron batch
+> to streaming; on-call lead. Open to new roles (posted 2 weeks ago).
+
+**Candidate B — Marcus Bell (fictional)**
+
+> Senior Backend Engineer — C#/.NET, AWS serverless, integrations. 12 yrs.
+> Currently: platform team at a healthcare martech co, 4 years. Deep in
+> third-party integrations, dbt/Snowflake pipelines, no streaming-at-scale
+> work. No availability signal.
+
+**Candidate C — Dana Okafor (fictional)**
+
+> Senior Backend Engineer — Go, distributed KV stores. 6 yrs. **Profile
+> carries a pinned note: "I am not job searching. Applications are being
+> submitted using my name — if you receive one, it is not from me."**
+
+### The beats
+
+**Beat 0 — governance is live.**
+Say: *"Check the covenant — am I allowed to infer a candidate's ethnicity
+from their name?"*
+Expect: a `check_covenant` call → **forbid (explicit rule)**. This proves
+the policy is loaded and distinguishing real rules from unknowns.
+
+**Beat 1 — the screen.**
+Paste the role, then the three candidates. Say: *"Screen and rank these
+against the role. Log each decision."*
+Expect: `log_screening_decision` calls (rank/score/hold) appearing
+**before** Claude states conclusions, and Dana flagged on provenance —
+the impersonation note — rather than judged on merit.
+
+> Field note: decisive phrasing matters. "Log each decision" in the ask
+> keeps informal analysis from slipping past the chain — in testing,
+> chatty exploratory ranking sometimes went unlogged until the model
+> corrected itself.
+
+**Beat 2 — the money moment.**
+Say: *"Eliminate the weakest candidate from my group."*
+Expect the exact sequence field-tested live:
+
+```
+check_covenant: reject_candidate → require_approval (explicit rule)
+log_screening_decision: <candidate> / reject → chain_hash=...
+  → REQUIRES HUMAN APPROVAL before proceeding
+```
+
+Claude **stops and asks for your explicit yes**. This is GDPR Art. 22 /
+EU AI Act Art. 14 human oversight, enforced by policy, not by mood. Give
+the yes; Claude records the approval against the decision's hash.
+
+**Beat 3 — the receipts.**
+Say: *"Give me my audit trail."*
+Expect: `verify_chain` → **"CHAIN INTACT: all N records verified. No
+tampering detected."** — then say *"export the evidence"* and expect a
+signed `.air-evidence` ZIP path, with **"chain fully verified at export
+time"** in the response. The integrity verdict is stamped inside the
+signed bundle itself; an export over a broken chain says so loudly
+instead.
+
+### The "before" (optional, brutal, recommended)
+
+Run Beats 1–3 once with the connector toggled **off**. When you ask for
+the audit trail, Claude will tell you the truth: it hasn't been keeping
+one, and any reconstruction is partly invented. That transcript next to
+the governed run is the entire product pitch with no slides.
+
+---
+
+## Part 3 — Independent verification (the point of it all)
+
+The evidence must verify **without trusting Claude or the demo machine**:
+
+```bash
+# Verify the chain from the terminal:
+air-blackbox replay --runs-dir ~/.air-blackbox/runs --verify
+#   ✅ CHAIN INTACT - N records verified. No tampering detected.
+
+# Prove tamper-evidence live (great closing move in a demo):
+#   open any .air.json in ~/.air-blackbox/runs, change one character,
+#   re-run the verify → ❌ CHAIN BROKEN at that exact record.
+
+# The bundle self-verifies anywhere, no install needed:
+unzip air-evidence-*.zip -d evidence && cd evidence
+python3 verify.py --key "$(cat ~/.air-blackbox/runs/.air-signing-key 2>/dev/null || echo air-blackbox-default)"
+```
+
+---
+
+## Part 4 — Troubleshooting (every one of these happened in real testing)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tools listed in settings but Claude says it has none / "point me at the repo" | Server never launched: relative `command` path, or wrong module name (`air_blackbox_mcp` — it's `air_blackbox.mcp_server`) | Use the absolute `air-blackbox-mcp` binary path; check `~/Library/Logs/Claude/mcp-server-air-blackbox.log` |
+| Every `check_covenant` returns forbid — even "say good morning" | Covenant is default-deny and matches exact snake_case names; free-text descriptions never match | Working as designed; the tools now answer "no rule (vocabulary miss)" and list valid names. Use the covenant's vocabulary |
+| `CHAIN BROKEN` at some old record | Fossil records from before a server update — multiple genesis chains in one store | History can't be healed (that's the guarantee). Archive the store (Part 1, step 4) and start clean |
+| `PARTIAL: N of M verified` | Unchained records (written without the trust layer) sitting in the same directory | Expected honesty, not an error — the verifiable portion is intact; move stray files out for a clean demo |
+| Claude analyzes candidates but logs nothing | Behavioral drift on informal asks | Say "log each decision" explicitly; decisions phrased decisively ("eliminate…", "reject…") reliably trigger the gate |
+
+---
+
+## What this demo proves
+
+1. **Recording**: every candidate-affecting decision written to a
+   tamper-evident, HMAC-chained record — before the conclusion is stated.
+2. **Enforcement**: forbidden actions blocked *and recorded*; rejections
+   require an explicit human yes (Art. 14 / GDPR Art. 22).
+3. **Proof**: a signed bundle carrying its own integrity verdict,
+   verifiable by an auditor with no AIR install and no trust in anyone.
+
+What it deliberately does **not** claim: that logging makes a decision
+lawful, that it audits bias (that needs demographic outcome data the
+gateway never sees), or that a covenant substitutes for a written role
+spec. The model will ask for a JD before ranking on merit — let it.

--- a/examples/recruiting_demo.py
+++ b/examples/recruiting_demo.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""End-to-end AIR Blackbox demo: an AI recruiting screener under governance.
+
+Scenario: a recruiting agent screens candidates for a role. Every LLM call
+goes through the AIR gateway (recorded, chained, signed). A covenant declares
+what the agent may do. We then:
+
+  1. Route screening calls through the gateway (tamper-evident records)
+  2. Verify the chain
+  3. Export the audit trail to a queryable Parquet lake
+  4. Run a candidate-outreach browser session under a covenant -> session passport
+  5. Produce a signed evidence bundle a regulator/client can verify
+
+Run:  python examples/recruiting_demo.py --gateway http://127.0.0.1:8080
+It expects an AIR gateway running with RUNS_DIR pointing at --runs.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+CANDIDATES = [
+    ("Alice Chen", "Senior Backend Engineer, 8y Go/Python, ex-Stripe"),
+    ("Bob Martins", "Frontend Engineer, 3y React, bootcamp grad"),
+    ("Carla Diaz", "Staff SRE, 11y, led 3 platform migrations"),
+    ("Dan Okafor", "New-grad SWE, strong algorithms, no industry exp"),
+    ("Erin Walsh", "Engineering Manager, 6y IC + 4y management"),
+]
+
+
+def screen_candidate(gateway, name, blurb):
+    """One screening decision = one governed, recorded LLM call."""
+    body = json.dumps({
+        "model": "gpt-4",
+        "messages": [
+            {"role": "system", "content": "You screen candidates for a Senior Backend role. Reply with a one-line recommendation."},
+            {"role": "user", "content": f"Candidate: {name}. Background: {blurb}. Screen for a Senior Backend Engineer role."},
+        ],
+    }).encode()
+    req = urllib.request.Request(
+        f"{gateway}/v1/chat/completions", data=body,
+        headers={"Content-Type": "application/json",
+                 "X-Session-ID": "recruiting-demo"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        run_id = resp.headers.get("x-run-id", "?")
+        json.loads(resp.read())
+    return run_id
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--gateway", default="http://127.0.0.1:8080")
+    ap.add_argument("--runs", default="./demo-runs")
+    args = ap.parse_args()
+
+    print("STEP 1: Screen candidates through the AIR gateway")
+    print("-" * 60)
+    for name, blurb in CANDIDATES:
+        run_id = screen_candidate(args.gateway, name, blurb)
+        print(f"  screened {name:16s} -> recorded run {run_id[:8]}")
+    print(f"\n  {len(CANDIDATES)} screening decisions recorded, each a signed "
+          f"chain link.\n")
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "sdk"))
+
+    print("STEP 2: Verify the audit chain")
+    print("-" * 60)
+    from air_blackbox.replay.engine import ReplayEngine
+    # The verifier auto-discovers the gateway's generated .air-signing-key
+    # from the runs directory - no key handling needed (zero-config).
+    engine = ReplayEngine(runs_dir=args.runs)
+    total = engine.load()
+    result = engine.verify_chain()
+    print(f"  {total} records loaded, chain "
+          f"{'INTACT' if result.intact else 'BROKEN'}, "
+          f"{result.verified_records} records verified.\n")
+
+    print("STEP 3: Export the audit trail to a queryable lake")
+    print("-" * 60)
+    try:
+        from air_blackbox.lake import export_records, verify_lake
+        lake_dir = os.path.join(os.path.dirname(args.runs), "demo-lake")
+        n = export_records(args.runs, lake_dir)
+        lv = verify_lake(lake_dir, runs_dir=args.runs)
+        print(f"  exported {n} records to Parquet; lake chain intact: "
+              f"{lv.intact}\n")
+    except ImportError:
+        print("  (skipped: pip install air-blackbox[lake])\n")
+
+    print("STEP 4: Candidate outreach as a governed browser session")
+    print("-" * 60)
+    from air_blackbox.passport import BrowserSession
+    cov = os.path.join(os.path.dirname(__file__), "..", "sdk", "air_blackbox",
+                       "gate", "examples", "linkedin-sourcing.covenant.yaml")
+    with BrowserSession(runs_dir=os.path.join(os.path.dirname(args.runs),
+                        "demo-passport"), covenant=cov,
+                        signing_key="demo-key") as s:
+        for name, _ in CANDIDATES[:3]:
+            s.action("read_profile", target=f"linkedin.com/in/{name}")
+            d = s.action("send_message", target=f"linkedin.com/in/{name}")
+            if d.needs_approval:
+                s.approve(d, approver="recruiter@demo")  # human clicks approve
+        s.action("scrape_search_page")  # agent overreach -> blocked + flagged
+    passport = s.passport()
+    print(f"  verdict: {passport.verdict}")
+    print(f"  actions: {passport.action_counts}")
+    print(f"  human approvals: {passport.approvals}, blocked: {passport.blocked}")
+    print(f"  chain intact: {passport.chain_intact}\n")
+
+    print("STEP 5: Signed evidence bundle (hand to auditor/client)")
+    print("-" * 60)
+    bundle = s.export_passport()
+    print(f"  passport bundle: {os.path.basename(bundle)}")
+    print("\nDONE. Every decision recorded, chained, governed, and provable.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sdk/air_blackbox/gate/examples/linkedin-sourcing.covenant.yaml
+++ b/sdk/air_blackbox/gate/examples/linkedin-sourcing.covenant.yaml
@@ -10,6 +10,9 @@ version: "1.0"
 description: "Accountable browser sourcing: read freely, act with a human"
 
 rules:
+  # A human's explicit approval of a gated action is always recordable.
+  - permit: human_approval
+
   # Viewing and research - permitted (a recruiter would do this by hand)
   - permit: navigate
   - permit: read_profile

--- a/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml
+++ b/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml
@@ -16,6 +16,10 @@ version: "1.0"
 description: "ADM-safe policy for candidate sourcing and screening agents"
 
 rules:
+  # Recording a human's explicit approval of a gated action is itself a
+  # governance event and is always permitted (it is the Article 14 sign-off).
+  - permit: human_approval
+
   # Research and enrichment - permitted (no candidate-affecting decision)
   - permit: search_candidates
   - permit: read_profile

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -48,7 +48,8 @@ While this connector is enabled you MUST:
    the policy blocked it.
 3. If record_action says REQUIRES HUMAN APPROVAL, stop and ask the user to
    explicitly approve. Only proceed after they clearly say yes, then call
-   record_action again with action "human_approved_<original_action>".
+   record_action with action "human_approval" and a detail naming what was
+   approved (e.g. "reject_candidate for Dana Okafor, approved by user").
 4. When unsure whether something is allowed, call check_covenant first.
 5. When the user asks for proof, a report, or an audit trail, call
    verify_chain and export_evidence.

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -36,8 +36,28 @@ RUNS_DIR = os.environ.get(
     "AIR_RUNS_DIR", os.path.expanduser("~/.air-blackbox/runs"))
 COVENANT_PATH = os.environ.get("AIR_COVENANT", "")
 
+_INSTRUCTIONS = """AIR Blackbox is active: this conversation is governed and
+its agent actions are recorded into a tamper-evident audit chain.
+
+While this connector is enabled you MUST:
+1. Before any consequential or externally-visible action (reading a person's
+   profile, drafting or sending outreach, scoring/advancing/rejecting a
+   candidate, writing to another system), call record_action with a short
+   action name (snake_case) and a one-line detail.
+2. If record_action says BLOCKED, do not perform the action. Tell the user
+   the policy blocked it.
+3. If record_action says REQUIRES HUMAN APPROVAL, stop and ask the user to
+   explicitly approve. Only proceed after they clearly say yes, then call
+   record_action again with action "human_approved_<original_action>".
+4. When unsure whether something is allowed, call check_covenant first.
+5. When the user asks for proof, a report, or an audit trail, call
+   verify_chain and export_evidence.
+
+This is not optional bookkeeping: the recorded chain is the user's
+compliance evidence. Unrecorded actions do not exist for audit purposes."""
+
 _auth_verifier, _auth_settings = build_auth()
-app = FastMCP("air-blackbox",
+app = FastMCP("air-blackbox", instructions=_INSTRUCTIONS,
               token_verifier=_auth_verifier, auth=_auth_settings)
 _covenant: Optional[Covenant] = (
     Covenant.from_yaml(COVENANT_PATH) if COVENANT_PATH else None)
@@ -159,6 +179,28 @@ def export_evidence() -> str:
                       "records": len(engine._raw_records)},
         signing_key=key, output_dir=runs)
     return f"Evidence bundle written: {path} ({len(engine._raw_records)} records)"
+
+
+@app.prompt()
+def governed_sourcing(role: str = "the open role") -> str:
+    """Start a recorded, policy-governed candidate sourcing session."""
+    return f"""You are helping me source and screen candidates for {role}.
+This session is governed by AIR Blackbox: record every consequential step
+with record_action (profile reads, summaries, drafts, and especially any
+send/score/advance/reject decision), honor BLOCKED decisions, and pause for
+my explicit approval whenever an action requires it. At the end of the
+session, run verify_chain and export_evidence so I have the signed audit
+trail. Begin by asking me for the candidates or search criteria."""
+
+
+@app.prompt()
+def compliance_report() -> str:
+    """Verify the audit chain and produce the evidence bundle."""
+    return """Please verify the integrity of my recorded agent activity and
+produce my compliance evidence: call verify_chain, summarize what it shows
+in plain language (what was recorded, whether anything was blocked or
+required approval), then call export_evidence and tell me where the signed
+bundle is."""
 
 
 def main():

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -56,11 +56,42 @@ While this connector is enabled you MUST:
 This is not optional bookkeeping: the recorded chain is the user's
 compliance evidence. Unrecorded actions do not exist for audit purposes."""
 
+_covenant: Optional[Covenant] = (
+    Covenant.from_yaml(COVENANT_PATH) if COVENANT_PATH else None)
+
+
+def _covenant_vocabulary(covenant: Covenant) -> str:
+    """The covenant is default-deny: an action name with no rule is forbidden.
+    Claude therefore needs the exact vocabulary, or every natural-language
+    action description silently reads as forbid."""
+    by_action: dict = {"permit": [], "require_approval": [], "forbid": []}
+    for rule in covenant.rules:
+        by_action.setdefault(rule.action.value, []).append(rule.target)
+    lines = [f"\nActive covenant: '{covenant.agent}'. It is DEFAULT-DENY and "
+             "matches EXACT action names only - always use these snake_case "
+             "names with record_action/check_covenant, never free-text "
+             "descriptions:"]
+    for kind in ("permit", "require_approval", "forbid"):
+        if by_action.get(kind):
+            lines.append(f"  {kind}: {', '.join(sorted(set(by_action[kind])))}")
+    lines.append("Unlisted actions are treated as forbidden by default; use "
+                 "check_covenant to test a name before relying on it.")
+    return "\n".join(lines)
+
+
+if _covenant:
+    _INSTRUCTIONS += "\n" + _covenant_vocabulary(_covenant)
+
 _auth_verifier, _auth_settings = build_auth()
 app = FastMCP("air-blackbox", instructions=_INSTRUCTIONS,
               token_verifier=_auth_verifier, auth=_auth_settings)
-_covenant: Optional[Covenant] = (
-    Covenant.from_yaml(COVENANT_PATH) if COVENANT_PATH else None)
+
+
+def _rule_exists(action: str, context: dict) -> bool:
+    """True if any covenant rule targets this action name at all - used to
+    distinguish an explicit policy decision from a default-deny vocabulary
+    miss, which must never masquerade as corroboration."""
+    return any(rule.matches(action, context) for rule in _covenant.rules)
 
 # Per-tenant chains, keyed by the authenticated OAuth subject. Without auth
 # every request shares the single "_local" tenant.
@@ -95,7 +126,10 @@ def _tenant_runs_dir(tenant: str) -> str:
 def _tenant_chain(tenant: str) -> AuditChain:
     chain = _chains.get(tenant)
     if chain is None:
-        chain = AuditChain(runs_dir=_tenant_runs_dir(tenant))
+        # resume=True: a server restart continues the tenant's existing chain
+        # instead of starting a second genesis-rooted chain in the same
+        # directory (which could never verify as one).
+        chain = AuditChain(runs_dir=_tenant_runs_dir(tenant), resume=True)
         _chains[tenant] = chain
     return chain
 
@@ -112,9 +146,11 @@ def record_action(action: str, detail: str = "", model: str = "",
     """
     tenant = _current_tenant()
     decision = "permit"
+    no_rule = False
     if _covenant:
         context = {"model": model, "tokens_total": tokens_total,
                    "category": category, "detail": detail}
+        no_rule = not _rule_exists(action, context)
         decision = _covenant.evaluate(action, context).value
 
     record = {
@@ -133,7 +169,16 @@ def record_action(action: str, detail: str = "", model: str = "",
     chain_hash = _tenant_chain(tenant).write(record)
 
     if decision == "forbid":
-        return (f"BLOCKED by covenant (recorded, chain_hash={chain_hash}). "
+        if no_rule:
+            return (
+                f"NO RULE MATCHED: the covenant has no rule named "
+                f"'{action}' and is default-deny, so this was recorded as "
+                f"blocked (chain_hash={chain_hash}). This is a vocabulary "
+                f"miss, NOT an explicit policy decision. Re-record using one "
+                f"of the covenant's exact action names (see check_covenant "
+                f"or the server instructions), or ask the user how to "
+                f"classify this action.")
+        return (f"BLOCKED by covenant rule (recorded, chain_hash={chain_hash}). "
                 f"Do not perform this action.")
     if decision == "require_approval":
         return (f"Recorded (chain_hash={chain_hash}) but this action "
@@ -144,11 +189,19 @@ def record_action(action: str, detail: str = "", model: str = "",
 
 @app.tool()
 def check_covenant(action: str, category: str = "") -> str:
-    """Check what the loaded covenant says about an action before doing it."""
+    """Check what the loaded covenant says about an action name before doing
+    it. Uses EXACT matching against the covenant's snake_case action names -
+    free-text descriptions will report 'no rule' (default-deny)."""
     if not _covenant:
         return "No covenant loaded (set AIR_COVENANT). Default: unrestricted."
-    decision = _covenant.evaluate(action, {"category": category})
-    return f"Covenant '{_covenant.agent}': {action} -> {decision.value}"
+    context = {"category": category}
+    decision = _covenant.evaluate(action, context)
+    if not _rule_exists(action, context):
+        return (f"Covenant '{_covenant.agent}': no rule named '{action}' - "
+                f"default-deny applies (forbid). This reflects the covenant's "
+                f"vocabulary, not a judgment about the action itself."
+                + _covenant_vocabulary(_covenant))
+    return f"Covenant '{_covenant.agent}': {action} -> {decision.value} (explicit rule)"
 
 
 @app.tool()
@@ -157,11 +210,21 @@ def verify_chain() -> str:
     engine = ReplayEngine(runs_dir=_tenant_runs_dir(_current_tenant()))
     total = engine.load()
     result = engine.verify_chain()
-    if result.intact:
-        return (f"CHAIN INTACT: {result.verified_records} of {total} records "
-                f"verified. No tampering detected.")
-    return (f"CHAIN BROKEN at record {result.first_break_at} "
-            f"(run {result.first_break_run_id}).")
+    if not result.intact:
+        return (f"CHAIN BROKEN at record {result.first_break_at} "
+                f"(run {result.first_break_run_id}). "
+                f"{result.verified_records} of {total} verified before the break.")
+    if total == 0:
+        return "No records yet: nothing to verify."
+    if result.verified_records < total:
+        # Never say INTACT when part of the evidence is outside the chain.
+        unchained = total - result.records_with_hash
+        return (f"PARTIAL: {result.verified_records} of {total} records "
+                f"verified; {unchained} carry no chain hash and CANNOT be "
+                f"verified for tampering. The verifiable portion is intact, "
+                f"but this store is not fully attestable - tell the user.")
+    return (f"CHAIN INTACT: all {result.verified_records} records verified. "
+            f"No tampering detected.")
 
 
 @app.tool()

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -181,6 +181,32 @@ def export_evidence() -> str:
     return f"Evidence bundle written: {path} ({len(engine._raw_records)} records)"
 
 
+@app.tool()
+def log_screening_decision(candidate: str, decision: str,
+                           rationale: str = "") -> str:
+    """REQUIRED whenever you evaluate, rank, advance, reject, or recommend
+    an outcome for a candidate - even informally in conversation. Call this
+    BEFORE stating the decision to the user.
+
+    decision must be one of: advance, reject, score, rank, shortlist, hold.
+    Candidate-affecting decisions are automated decision-making under GDPR
+    Art 22 / EU AI Act Art 14: if this returns REQUIRES HUMAN APPROVAL, stop
+    and get the user's explicit yes before finalizing anything.
+    """
+    action_map = {
+        "advance": "advance_candidate", "reject": "reject_candidate",
+        "score": "score_candidate", "rank": "rank_candidates",
+        "shortlist": "rank_candidates", "hold": "score_candidate",
+    }
+    action = action_map.get(decision.strip().lower(), "score_candidate")
+    return record_action(
+        action=action,
+        detail=f"candidate={candidate[:100]}; decision={decision}; "
+               f"rationale={rationale[:300]}",
+        category="screening",
+    )
+
+
 @app.prompt()
 def governed_sourcing(role: str = "the open role") -> str:
     """Start a recorded, policy-governed candidate sourcing session."""

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -230,18 +230,44 @@ def verify_chain() -> str:
 @app.tool()
 def export_evidence() -> str:
     """Package all recorded actions into a signed .air-evidence ZIP."""
+    from dataclasses import asdict
+
     from air_blackbox.export.evidence_bundle import generate_evidence_zip
     tenant = _current_tenant()
     runs = _tenant_runs_dir(tenant)
     engine = ReplayEngine(runs_dir=runs)
-    engine.load()
+    total = engine.load()
     key = os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")
+
+    # The bundle must never quietly attest a broken or partial chain: verify
+    # first and stamp the result INTO the signed payload, so a downstream
+    # auditor sees the integrity verdict before anything else.
+    verification = engine.verify_chain()
+    fully_intact = verification.intact and verification.verified_records == total
+
     path = generate_evidence_zip(
         chain_entries=engine._raw_records,
         scan_results={"source": "air-blackbox MCP server", "tenant": tenant,
-                      "records": len(engine._raw_records)},
+                      "records": total,
+                      "chain_verification": {
+                          "fully_intact": fully_intact,
+                          **asdict(verification)}},
         signing_key=key, output_dir=runs)
-    return f"Evidence bundle written: {path} ({len(engine._raw_records)} records)"
+
+    if not verification.intact:
+        return (f"WARNING - BROKEN CHAIN EXPORTED: {path}. The chain fails "
+                f"verification at record {verification.first_break_at} (run "
+                f"{verification.first_break_run_id}); the bundle is signed and "
+                f"its manifest records the failure, so it attests a broken "
+                f"chain - it is NOT clean compliance evidence. Tell the user.")
+    if not fully_intact:
+        unchained = total - verification.records_with_hash
+        return (f"WARNING - PARTIAL CHAIN EXPORTED: {path}. "
+                f"{verification.verified_records} of {total} records verified; "
+                f"{unchained} carry no chain hash. The manifest records this. "
+                f"Tell the user.")
+    return (f"Evidence bundle written: {path} ({total} records, chain fully "
+            f"verified at export time; verification stamped into the manifest)")
 
 
 @app.tool()

--- a/sdk/air_blackbox/passport/session.py
+++ b/sdk/air_blackbox/passport/session.py
@@ -130,7 +130,7 @@ class BrowserSession:
             "run_id": str(uuid.uuid4()),
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "type": "human_approval",
-            "action": "approve",
+            "action": "human_approval",
             "approves_run_id": decision.run_id,
             "approves_action": decision.action,
             "approver": approver,

--- a/sdk/air_blackbox/trust/chain.py
+++ b/sdk/air_blackbox/trust/chain.py
@@ -43,6 +43,7 @@ class AuditChain:
         self,
         runs_dir: str = "./runs",
         signing_key: Optional[str] = None,
+        resume: bool = False,
     ):
         self.runs_dir = runs_dir
         self._key = (
@@ -52,7 +53,41 @@ class AuditChain:
         self._prev_hash = self.GENESIS
         self._lock = threading.Lock()
         self._record_count = 0
+        self._seq = 0
         os.makedirs(self.runs_dir, exist_ok=True)
+        if resume:
+            self._resume()
+
+    def _resume(self) -> None:
+        """Continue an existing chain instead of restarting at genesis.
+
+        Without this, every new process writing into the same runs directory
+        starts a second genesis-rooted chain, and the combined records can
+        never verify as one. Mirrors the verifier: walk chained records in
+        (chain_seq, timestamp) order, advancing the expected digest.
+        """
+        import glob as _glob
+
+        records = []
+        for path in _glob.glob(os.path.join(self.runs_dir, "*.air.json")):
+            try:
+                with open(path) as f:
+                    rec = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                continue
+            if rec.get("chain_hash"):
+                records.append(rec)
+        records.sort(key=lambda r: (r.get("chain_seq") or 0,
+                                    r.get("timestamp") or ""))
+
+        for rec in records:
+            clean = {k: v for k, v in rec.items() if k != "chain_hash"}
+            record_bytes = json.dumps(clean, sort_keys=True).encode("utf-8")
+            h = hmac.new(self._key, self._prev_hash + record_bytes,
+                         hashlib.sha256)
+            self._prev_hash = h.digest()
+            self._record_count += 1
+            self._seq = max(self._seq, int(rec.get("chain_seq") or 0))
 
     def write(self, record: dict) -> Optional[str]:
         """Write a record with chain_hash to the runs directory.
@@ -76,6 +111,12 @@ class AuditChain:
                 if "timestamp" not in record:
                     record["timestamp"] = datetime.utcnow().isoformat() + "Z"
 
+                # The writer owns the chain fields: never trust caller values,
+                # and stamp append order so verifiers replay it exactly even
+                # when timestamps collide or the process restarts.
+                record.pop("chain_hash", None)
+                record["chain_seq"] = self._seq + 1
+
                 # Compute chain hash per spec: HMAC(key, prev_hash || JSON(record))
                 record_bytes = json.dumps(record, sort_keys=True).encode("utf-8")
                 h = hmac.new(
@@ -93,6 +134,7 @@ class AuditChain:
                 # Advance chain state
                 self._prev_hash = h.digest()
                 self._record_count += 1
+                self._seq += 1
 
                 return chain_hash
 

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -197,3 +197,22 @@ def test_export_clean_chain_reports_verified(tmp_path, monkeypatch):
     out = srv.export_evidence()
     assert "chain fully verified at export time" in out
     assert "WARNING" not in out
+
+
+def test_human_approval_flow_is_recordable(tmp_path, monkeypatch):
+    # Field-test regression: a decision requires approval, and recording the
+    # human's approval must be permitted (not a default-deny vocabulary miss).
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", _load_recruiting_covenant(srv))
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    gated = srv.log_screening_decision("Dana Okafor", "reject", "provenance only")
+    assert "REQUIRES HUMAN APPROVAL" in gated
+
+    approved = srv.record_action(
+        "human_approval", detail="reject Dana approved by user", category="screening")
+    assert approved.startswith("Recorded")           # not blocked
+    assert "NO RULE" not in approved and "BLOCKED" not in approved
+
+    assert "CHAIN INTACT: all 2 records verified" in srv.verify_chain()

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -85,3 +85,74 @@ def test_tenant_chains_are_isolated(tmp_path, monkeypatch):
     assert os.path.isfile(os.path.join(tmp_path, "alice", "a1.air.json"))
     assert os.path.isfile(os.path.join(tmp_path, "bob", "b1.air.json"))
     assert not os.path.isfile(os.path.join(tmp_path, "alice", "b1.air.json"))
+
+
+# --- field-test regressions: covenant vocabulary + honest verification ---
+
+def _load_recruiting_covenant(srv):
+    from air_blackbox.gate.covenant import Covenant
+    path = os.path.join(os.path.dirname(__file__), "..", "air_blackbox",
+                        "gate", "examples", "recruiting-screener.covenant.yaml")
+    return Covenant.from_yaml(path)
+
+
+def test_check_covenant_distinguishes_no_rule_from_explicit(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", _load_recruiting_covenant(srv))
+
+    # Free-text action name: vocabulary miss, not a policy judgment.
+    out = srv.check_covenant("say good morning to the user")
+    assert "no rule" in out
+    assert "vocabulary" in out
+    assert "read_profile" in out          # teaches the vocabulary
+
+    # Explicit rule: reported as such.
+    out = srv.check_covenant("infer_protected_attributes")
+    assert "explicit rule" in out and "forbid" in out
+
+
+def test_record_action_no_rule_message(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", _load_recruiting_covenant(srv))
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    out = srv.record_action("reviewed 3 candidate LinkedIn profiles")
+    assert "NO RULE MATCHED" in out and "vocabulary miss" in out
+
+    out = srv.record_action("infer_protected_attributes")
+    assert "BLOCKED by covenant rule" in out
+
+
+def test_verify_chain_partial_is_not_intact(tmp_path, monkeypatch):
+    import json
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    srv.record_action("read_profile")
+    # A stray unchained record lands in the same store.
+    with open(os.path.join(tmp_path, "stray.air.json"), "w") as f:
+        json.dump({"run_id": "stray", "timestamp": "2026-01-01T00:00:00Z"}, f)
+
+    out = srv.verify_chain()
+    assert "PARTIAL" in out and "CANNOT be verified" in out
+    assert "INTACT" not in out
+
+
+def test_chain_resumes_across_server_restarts(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+
+    srv._chains.clear()
+    srv.record_action("read_profile")
+    srv.record_action("draft_message")
+
+    # Simulate a Desktop restart: fresh chain objects over the same store.
+    srv._chains.clear()
+    srv.record_action("read_profile")
+
+    out = srv.verify_chain()
+    assert "CHAIN INTACT: all 3 records verified" in out

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -156,3 +156,44 @@ def test_chain_resumes_across_server_restarts(tmp_path, monkeypatch):
 
     out = srv.verify_chain()
     assert "CHAIN INTACT: all 3 records verified" in out
+
+
+def test_export_warns_on_broken_chain(tmp_path, monkeypatch):
+    import json, glob, zipfile
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    srv.record_action("read_profile")
+    srv.record_action("draft_message")
+    # Tamper with the first record.
+    path = sorted(glob.glob(os.path.join(tmp_path, "*.air.json")))[0]
+    with open(path) as f:
+        rec = json.load(f)
+    rec["action"] = "TAMPERED"
+    with open(path, "w") as f:
+        json.dump(rec, f)
+
+    out = srv.export_evidence()
+    assert "WARNING - BROKEN CHAIN EXPORTED" in out
+    assert "NOT clean compliance evidence" in out
+
+    # The signed payload itself carries the failure.
+    zpath = glob.glob(os.path.join(tmp_path, "air-evidence-*.zip"))[0]
+    with zipfile.ZipFile(zpath) as z:
+        scan = json.loads(z.read("scan_results.json"))
+    assert scan["chain_verification"]["fully_intact"] is False
+    assert scan["chain_verification"]["intact"] is False
+
+
+def test_export_clean_chain_reports_verified(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    srv.record_action("read_profile")
+    out = srv.export_evidence()
+    assert "chain fully verified at export time" in out
+    assert "WARNING" not in out


### PR DESCRIPTION
## What does this PR do?
Makes the governance MCP server usable by non-technical people, hardens it against everything a real recruiting session threw at it, and ships a reproducible demo (8 commits).

**Zero-code UX.** The connector now carries its own operating rules as server-level MCP instructions (record every consequential action, honor BLOCKED, pause for explicit human approval) plus two ready-made prompts (`governed_sourcing`, `compliance_report`), so a recruiter who just chats gets governance without invoking anything by name. Adds a purpose-named `log_screening_decision` tool, which the model reaches for far more reliably than a generic record rule.

**Three bugs surfaced by live field testing, all fixed with regression tests:**
- **Chain restarts** — the Python `AuditChain` always restarted at genesis, so every server restart began a second chain in the same store and the combined records could never verify as one. Now supports `resume=True` (walks existing chained records like the verifier) and stamps `chain_seq` like the Go writer.
- **Dishonest verification** — `verify_chain` reported "CHAIN INTACT: 1 of 5 verified" (INTACT over a partial verify — the worst bug class for an attestation product). Now reports PARTIAL with an explicit cannot-be-verified count, and INTACT only when every record verifies.
- **Default-deny with no discoverable vocabulary** — the covenant matches exact action names, so free-text descriptions all read as forbid (including "say good morning"), and a vocabulary miss was indistinguishable from an explicit policy decision. Server instructions now carry the covenant vocabulary, and both tools distinguish NO RULE (default-deny) from an explicit rule.

**Evidence export integrity** — `export_evidence` now verifies the chain first, stamps the verdict inside the signed payload, and warns loudly on broken/partial chains instead of quietly signing compromised evidence.

**Canonical `human_approval` action** — a demo surfaced that recording a human's approval hit default-deny and got blocked; approval is now one permitted action across the covenants, MCP instructions, and passport, so the full screen→gate→approve→verify→export flow completes clean.

**Demo assets** — `demo/governed_screening_demo.py` reproduces the whole flow (covenant enforcement, logged decisions, approval gate, verification, signed export, live tamper test) against the real engine in one command; `demo/desktop-demo-shotlist.md` scripts the Claude Desktop recording; plus a full step-by-step operator guide with fictional candidates.

## Type of change
- [x] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] New compliance check
- [ ] Refactor / code quality
- [x] Trust layer integration

## EU AI Act articles affected
Article 14 (human oversight: enforced approval gate on candidate-affecting decisions), Article 12 (record-keeping: honest verification, restart-safe chains). GDPR Art 22 via the recruiting approval flow.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (139 Python tests; Go build + vet clean)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (all additive; record format unchanged, chain_seq additive)

## Additional notes
Every fix in this PR came from a real recruiting session run through the connector, not from CI or code review — three field runs, three bugs, each now a regression test. The demo script runs end-to-end and was verified in this session, including catching a tampered record at the exact break. Recommend **squash merge**, as with #37 and #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_