### PR TITLE
Gate Ed25519 receipts on every recorded action in the MCP server

### DIFF
--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -20,10 +20,13 @@ Claude Desktop config:
     "args": ["-m", "air_blackbox.mcp_server"]}}}
 """
 
+import logging
 import os
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
+
+logger = logging.getLogger("air_blackbox.mcp")
 
 from mcp.server.fastmcp import FastMCP
 
@@ -164,7 +167,13 @@ def _tenant_signer(tenant: str) -> ReceiptSigner:
                     f.write(priv.hex())
                 os.chmod(key_path, 0o600)
             except OSError:
-                pass
+                # Non-fatal: signing still works this session with the
+                # in-memory key, but the keyfile could not be written, so the
+                # tenant's public key will change on restart. Warn the
+                # operator; do not fail the request.
+                logger.warning(
+                    "could not persist receipt key at %s; public key will not "
+                    "be stable across restarts", key_path)
         signer = ReceiptSigner(private_key=priv,
                                hmac_key=os.environ.get("TRUST_SIGNING_KEY"))
         _signers[tenant] = signer

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -28,6 +28,7 @@ from typing import Optional
 from mcp.server.fastmcp import FastMCP
 
 from air_blackbox.gate.covenant import Covenant
+from air_blackbox.gate.receipt import ActionReceipt, ReceiptSigner, hash_payload
 from air_blackbox.mcp_auth import build_auth
 from air_blackbox.replay.engine import ReplayEngine
 from air_blackbox.trust.chain import AuditChain
@@ -52,7 +53,8 @@ While this connector is enabled you MUST:
    approved (e.g. "reject_candidate for Dana Okafor, approved by user").
 4. When unsure whether something is allowed, call check_covenant first.
 5. When the user asks for proof, a report, or an audit trail, call
-   verify_chain and export_evidence.
+   verify_chain (records unaltered) and verify_receipts (who authorized
+   each action, via public-key signatures), then export_evidence.
 
 This is not optional bookkeeping: the recorded chain is the user's
 compliance evidence. Unrecorded actions do not exist for audit purposes."""
@@ -135,6 +137,58 @@ def _tenant_chain(tenant: str) -> AuditChain:
     return chain
 
 
+# Per-tenant Gate receipt signers. Ed25519 (or ML-DSA-65 if available) gives
+# every action a non-repudiable signature that anyone can verify with the
+# PUBLIC key alone - no shared secret, unlike the HMAC chain. This is the Gate
+# "bilateral receipt": the chain proves nothing was altered, the receipt
+# proves who authorized it.
+_signers: dict = {}
+
+
+def _tenant_signer(tenant: str) -> ReceiptSigner:
+    signer = _signers.get(tenant)
+    if signer is None:
+        runs = _tenant_runs_dir(tenant)
+        os.makedirs(runs, exist_ok=True)
+        key_path = os.path.join(runs, ".air-receipt-key")
+        # Own the key so the tenant's public key is stable across restarts.
+        # Any 32 random bytes is a valid Ed25519 seed.
+        priv = None
+        try:
+            with open(key_path) as f:
+                priv = bytes.fromhex(f.read().strip())
+        except (OSError, ValueError):
+            priv = os.urandom(32)
+            try:
+                with open(key_path, "w") as f:
+                    f.write(priv.hex())
+                os.chmod(key_path, 0o600)
+            except OSError:
+                pass
+        signer = ReceiptSigner(private_key=priv,
+                               hmac_key=os.environ.get("TRUST_SIGNING_KEY"))
+        _signers[tenant] = signer
+    return signer
+
+
+def _sign_receipt(tenant: str, action: str, decision: str, detail: str,
+                  category: str) -> dict:
+    """Produce a signed Gate receipt for an action and return it as a dict to
+    embed in the chained record. The signature covers the action, decision,
+    and covenant hash - independently verifiable from the record alone."""
+    receipt = ActionReceipt(
+        agent_id=tenant,
+        action_name=action,
+        action_category=category or "",
+        payload_hash=hash_payload(detail) if detail else "",
+        covenant_hash=_covenant.hash if _covenant else "",
+        decision=decision,
+        authorized=(decision == "permit"),
+    )
+    _tenant_signer(tenant).sign_authorization(receipt)
+    return receipt.to_dict()
+
+
 @app.tool()
 def record_action(action: str, detail: str = "", model: str = "",
                   tokens_total: int = 0, category: str = "") -> str:
@@ -167,6 +221,10 @@ def record_action(action: str, detail: str = "", model: str = "",
     }
     if _covenant:
         record["covenant_hash"] = _covenant.hash
+    # Attach a signed Gate receipt: the record now carries a non-repudiable
+    # signature verifiable with the tenant's public key, chained for
+    # tamper-evidence.
+    record["receipt"] = _sign_receipt(tenant, action, decision, detail, category)
     chain_hash = _tenant_chain(tenant).write(record)
 
     if decision == "forbid":
@@ -229,6 +287,62 @@ def verify_chain() -> str:
 
 
 @app.tool()
+def verify_receipts() -> str:
+    """Verify the Ed25519 signature on every recorded action for this tenant.
+
+    Unlike verify_chain (which proves records were not altered, using the
+    shared HMAC key), this proves WHO authorized each action using public-key
+    signatures - anyone can verify with the public key, no secret needed."""
+    import json as _json
+
+    tenant = _current_tenant()
+    signer = _tenant_signer(tenant)
+    engine = ReplayEngine(runs_dir=_tenant_runs_dir(tenant))
+    engine.load()
+
+    checked = valid = 0
+    for raw in engine._raw_records:
+        r = raw.get("receipt")
+        if not r:
+            continue
+        checked += 1
+        if signer.verify_authorization(_receipt_from_dict(r)):
+            valid += 1
+
+    pub = signer.public_key_hex or "(hmac fallback - no public key)"
+    if checked == 0:
+        return f"No signed receipts yet. Signing method: {signer.method}."
+    if valid == checked:
+        return (f"ALL RECEIPTS VALID: {valid}/{checked} signatures verified "
+                f"({signer.method}). Public key: {pub}. Anyone can verify these "
+                f"with the public key alone - no shared secret required.")
+    return (f"RECEIPT FAILURE: only {valid} of {checked} signatures verified "
+            f"({signer.method}). {checked - valid} receipt(s) do not match - "
+            f"tell the user.")
+
+
+def _receipt_from_dict(d: dict) -> ActionReceipt:
+    """Reconstruct an ActionReceipt from a stored record for verification."""
+    from air_blackbox.gate.receipt import ReceiptStatus
+    r = ActionReceipt(
+        receipt_id=d.get("receipt_id", ""),
+        agent_id=d.get("agent_id", ""),
+        action_name=d.get("action_name", ""),
+        action_category=d.get("action_category", ""),
+        payload_hash=d.get("payload_hash", ""),
+        covenant_hash=d.get("covenant_hash", ""),
+        decision=d.get("decision", ""),
+        authorized=d.get("authorized", False),
+        parent_receipt_id=d.get("parent_receipt_id"),
+        authorization_sig=d.get("authorization_sig", ""),
+        created_at=d.get("created_at", ""),
+        signing_method=d.get("signing_method", ""),
+        signing_public_key=d.get("signing_public_key", ""),
+    )
+    return r
+
+
+@app.tool()
 def export_evidence() -> str:
     """Package all recorded actions into a signed .air-evidence ZIP."""
     from dataclasses import asdict
@@ -252,7 +366,11 @@ def export_evidence() -> str:
                       "records": total,
                       "chain_verification": {
                           "fully_intact": fully_intact,
-                          **asdict(verification)}},
+                          **asdict(verification)},
+                      # Publish the receipt public key so a third party can
+                      # verify every action's Ed25519 signature independently.
+                      "receipt_signing_method": _tenant_signer(tenant).method,
+                      "receipt_public_key": _tenant_signer(tenant).public_key_hex or ""},
         signing_key=key, output_dir=runs)
 
     if not verification.intact:

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -216,3 +216,55 @@ def test_human_approval_flow_is_recordable(tmp_path, monkeypatch):
     assert "NO RULE" not in approved and "BLOCKED" not in approved
 
     assert "CHAIN INTACT: all 2 records verified" in srv.verify_chain()
+
+
+def test_actions_carry_verifiable_ed25519_receipts(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+    srv._signers.clear()
+
+    srv.record_action("read_profile", detail="candidate A")
+    srv.record_action("draft_message", detail="hello")
+
+    out = srv.verify_receipts()
+    assert "ALL RECEIPTS VALID: 2/2" in out
+    assert "ed25519" in out
+    assert "Public key:" in out
+
+
+def test_receipt_public_key_is_stable_across_restart(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+
+    srv.record_action("read_profile")
+    pub1 = srv._tenant_signer("_local").public_key_hex
+
+    # Simulate a restart: drop the in-memory signer, reload from the keyfile.
+    srv._signers.clear()
+    pub2 = srv._tenant_signer("_local").public_key_hex
+    assert pub1 == pub2 and pub1
+
+
+def test_tampered_receipt_is_caught(tmp_path, monkeypatch):
+    import glob, json
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+
+    srv.record_action("read_profile", detail="candidate A")
+    # Forge the decision inside a stored receipt without re-signing.
+    path = glob.glob(os.path.join(tmp_path, "*.air.json"))[0]
+    with open(path) as f:
+        rec = json.load(f)
+    rec["receipt"]["decision"] = "permit"
+    rec["receipt"]["action_name"] = "bulk_export"
+    with open(path, "w") as f:
+        json.dump(rec, f)
+
+    out = srv.verify_receipts()
+    assert "RECEIPT FAILURE" in out


### PR DESCRIPTION
## What does this PR do?
Brings the full Gate bilateral-receipt guarantee into the governance MCP server. The Gate **covenant** engine was already wired in (`check_covenant`, the human-approval gate); this adds the missing half — a non-repudiable **Ed25519 signature** (ML-DSA-65 when the library is available) on every recorded action, embedded in the chained record.

**Two independent proofs now co-exist per action:**
- `verify_chain` (HMAC, shared key) proves no record was *altered* — tamper-evidence.
- The new `verify_receipts` tool proves *who authorized* each action, using public-key signatures that anyone can check with the published public key — **no shared secret required.** This is the property HMAC structurally cannot provide: evidence an adversarial third party (auditor, regulator, platform) can verify without being trusted with a key.

**Details:**
- Each tenant gets a stable Ed25519 keypair persisted alongside its runs (`.air-receipt-key`, 0600), so the public key survives restarts.
- `export_evidence` publishes the receipt public key and signing method in the signed manifest, so the bundle is independently verifiable end to end.
- Forging a stored receipt's decision without re-signing is caught (regression test).

**Design note:** this is *additive* — it does not route the MCP through `Gate.authorize()` wholesale. The full engine's synchronous approval-callback model doesn't fit the MCP's async "ask the human in chat" pattern (field-tested with a real recruiter), and Gate's own chain lacks the restart-resume fix merged in #41. So the covenant/approval/vocabulary/tenant/restart behavior is untouched; records simply gain a signed `receipt` object.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] New compliance check
- [ ] Refactor / code quality
- [x] Trust layer integration

## EU AI Act articles affected
Article 12 (record-keeping: non-repudiable, third-party-verifiable action receipts). Strengthens the evidentiary weight of the audit trail for high-risk-system logging.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (142 Python tests; Go build + vet clean)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (additive; records gain a `receipt` object, chain/replay/lake unaffected)

## Additional notes
Verified live in this session: three recorded actions returned `CHAIN INTACT` **and** `ALL RECEIPTS VALID: 3/3 (ed25519)` with a published public key; a forged stored receipt was caught as `RECEIPT FAILURE`; the exported bundle carries the Ed25519 public key. Recommend **squash merge**, as with #37/#40/#41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_