### PR TITLE
Make the MCP server deployable: trust the deployment host, /health, .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# The MCP image only needs pyproject.toml, README.md, and sdk/ (see
+# deploy/mcp/Dockerfile). Keep the build context small so deploys are fast -
+# without this, ~160 MB (mostly training/ and .git/) uploads on every deploy.
+.git/
+training/
+docs/
+bench/
+testdata/
+episodes/
+model/
+eval/
+sandbox/
+collector/
+deploy/helm/
+*.air-evidence
+*.air.json
+runs/
+.air-blackbox/
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+node_modules/

--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -21,6 +21,9 @@ primary_region = "iad"
   AIR_MCP_PORT = "8085"
   AIR_RUNS_DIR = "/data/runs"
   AIR_MCP_ISSUER_URL = "https://mcp.airblackbox.ai"
+  # Hosts the server trusts (DNS-rebinding protection). Include the raw
+  # fly.dev hostname so you can test before the custom domain is wired.
+  AIR_MCP_ALLOWED_HOSTS = "air-mcp.fly.dev,mcp.airblackbox.ai"
   # AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
   #
   # OAuth (resource-server). Production: point at your IdP's introspection

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -88,9 +88,53 @@ def _covenant_vocabulary(covenant: Covenant) -> str:
 if _covenant:
     _INSTRUCTIONS += "\n" + _covenant_vocabulary(_covenant)
 
+def _transport_security():
+    """DNS-rebinding protection trusts only localhost by default, which
+    rejects the real hostname behind a proxy (Fly, a load balancer, etc.).
+    List the public host(s) in AIR_MCP_ALLOWED_HOSTS (comma-separated); the
+    issuer host is trusted automatically. Set AIR_MCP_ALLOWED_HOSTS=* to
+    disable the check (only behind a trusted proxy that sets Host)."""
+    from urllib.parse import urlparse
+
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    raw = os.environ.get("AIR_MCP_ALLOWED_HOSTS", "").strip()
+    if raw == "*":
+        return TransportSecuritySettings(enable_dns_rebinding_protection=False)
+
+    hosts = {h.strip() for h in raw.split(",") if h.strip()}
+    issuer = os.environ.get("AIR_MCP_ISSUER_URL", "")
+    if issuer:
+        host = urlparse(issuer).netloc
+        if host:
+            hosts.add(host)
+    hosts.update({"localhost", "127.0.0.1"})
+    if not hosts:
+        return None
+    # Trust both bare host and host:port, and matching origins.
+    expanded = set()
+    for h in hosts:
+        expanded.add(h)
+        expanded.add(f"{h}:{os.environ.get('AIR_MCP_PORT', '8085')}")
+    origins = {f"https://{h}" for h in hosts} | {f"http://{h}" for h in hosts}
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=sorted(expanded),
+        allowed_origins=sorted(origins),
+    )
+
+
 _auth_verifier, _auth_settings = build_auth()
 app = FastMCP("air-blackbox", instructions=_INSTRUCTIONS,
-              token_verifier=_auth_verifier, auth=_auth_settings)
+              token_verifier=_auth_verifier, auth=_auth_settings,
+              transport_security=_transport_security())
+
+
+@app.custom_route("/health", methods=["GET"])
+async def _health(request):
+    """Unauthenticated liveness probe for load balancers / Fly health checks."""
+    from starlette.responses import JSONResponse
+    return JSONResponse({"status": "ok", "service": "air-blackbox-mcp"})
 
 
 def _rule_exists(action: str, context: dict) -> bool:


### PR DESCRIPTION
## What does this PR do?
Fixes what broke a real Fly.io deploy of the governance MCP server, found while standing up `air-mcp.fly.dev`.

- **Trust the deployment host.** The MCP SDK's DNS-rebinding protection only trusts `localhost` by default, so a deployed server returned `Invalid Host header` for its real hostname. The server now configures `TransportSecuritySettings` from `AIR_MCP_ALLOWED_HOSTS` (comma-separated), defaulting to the issuer host — so the connector works behind a real domain. Verified live: the deployed `https://air-mcp.fly.dev/mcp` now completes the MCP `initialize` handshake (`serverInfo: air-blackbox`).
- **`/health` endpoint.** Added a lightweight health route (`{"status":"ok","service":"air-blackbox-mcp"}`) so uptime checks and the deploy smoke test have something to hit.
- **`.dockerignore`.** The image only needs `pyproject.toml`, `README.md`, and `sdk/`, but `fly deploy` was uploading ~160 MB of build context every time (`training/` and `.git/` dominate). Excludes everything the image doesn't use.

## Type of change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] New compliance check
- [x] Refactor / code quality
- [x] Trust layer integration

## EU AI Act articles affected
N/A (operational/deployment fix; unblocks the hosted governance connector).

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (MCP suite green)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (host allowlist defaults preserve local/stdio behavior)

## Additional notes
Proven end to end in this session: after this change deployed, `/health` returns ok and the `/mcp` initialize handshake succeeds over HTTPS from the public hostname — the connector is live. Recommend **squash merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_