### PR TITLE
Binding history M1: countersigned chain head (external timestamp anchor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest cryptography pyarrow pyyaml
+        run: pip install pytest cryptography pyarrow pyyaml httpx
       - name: Test SDK
         run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest cryptography pyarrow pyyaml httpx
+        run: pip install pytest cryptography pyarrow pyyaml httpx mcp
       - name: Test SDK
         run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
 

--- a/sdk/air_blackbox/anchor/__init__.py
+++ b/sdk/air_blackbox/anchor/__init__.py
@@ -1,0 +1,22 @@
+"""Binding history - anchor the chain head to an external, operator-independent
+authority so a rewritten-and-re-signed history is detectable.
+
+AIR's chain + receipts prove nothing was ALTERED. But the operator holds the
+keys and could rewrite the whole chain and re-sign it. Anchoring the chain
+head to an RFC 3161 timestamp authority closes that: the TSA countersigns
+"this exact head existed at time T" with a key the operator does not control,
+so a rewritten head cannot inherit the old anchor.
+
+The claim this enables: "you can still lie, but not invisibly."
+
+See docs/decisions/0001-anchor-rail.md for why RFC 3161 (M1) over Rekor.
+"""
+
+from air_blackbox.anchor.head import compute_head
+from air_blackbox.anchor.tsa import (
+    AnchorResult,
+    timestamp_head,
+    verify_anchor_bytes,
+)
+
+__all__ = ["compute_head", "timestamp_head", "verify_anchor_bytes", "AnchorResult"]

--- a/sdk/air_blackbox/anchor/head.py
+++ b/sdk/air_blackbox/anchor/head.py
@@ -1,0 +1,49 @@
+"""The chain head: a single 32-byte value that commits to the entire history.
+
+Defined so it is computable by anyone with the records and NO secret key: it
+is the SHA-256 over the ordered list of (chain_seq, chain_hash) pairs. Every
+record's chain_hash already commits to that record's content and to the record
+before it, so this head changes if any record is altered, added, or removed -
+which is exactly what makes a rewritten history fail to match its old anchor.
+"""
+
+import glob
+import hashlib
+import json
+import os
+
+
+def compute_head(runs_dir: str, up_to_seq: int = None) -> str:
+    """Return the hex SHA-256 chain head for a runs directory, or "" if there
+    are no chained records.
+
+    Only records carrying a chain_hash participate: unchained records are
+    outside the chain (see the verifier), so they are outside the head too.
+
+    up_to_seq bounds the head to records with chain_seq <= up_to_seq. An anchor
+    is taken over the head at a sequence point; re-deriving the head over the
+    same bounded set later detects any rewrite of that history, while records
+    added afterwards legitimately advance the (unbounded) head.
+    """
+    entries = []
+    for path in glob.glob(os.path.join(runs_dir, "*.air.json")):
+        try:
+            with open(path) as f:
+                rec = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+        ch = rec.get("chain_hash")
+        if not ch:
+            continue
+        seq = rec.get("chain_seq") or 0
+        if up_to_seq is not None and seq > up_to_seq:
+            continue
+        entries.append((seq, ch))
+
+    if not entries:
+        return ""
+
+    entries.sort(key=lambda e: (e[0], e[1]))
+    # Canonical, key-free commitment over the ordered chain.
+    payload = json.dumps(entries, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()

--- a/sdk/air_blackbox/anchor/tsa.py
+++ b/sdk/air_blackbox/anchor/tsa.py
@@ -12,7 +12,8 @@ import tempfile
 from dataclasses import dataclass
 from typing import List, Optional
 
-import httpx
+# httpx is imported lazily inside the functions that POST/GET, so the module
+# loads - and offline verification with a provided CA works - without it.
 
 # Public RFC 3161 timestamp authorities, tried in order.
 DEFAULT_TSA_URLS = [
@@ -61,6 +62,8 @@ def timestamp_head(head_hex: str,
     """Obtain an RFC 3161 timestamp over the head from the first reachable TSA."""
     if not head_hex:
         return AnchorResult(ok=False, head=head_hex, error="no chain head to anchor")
+    import httpx
+
     urls = tsa_urls or DEFAULT_TSA_URLS
     try:
         tsq = make_query(head_hex)
@@ -114,7 +117,9 @@ def verify_anchor_bytes(head_hex: str, tsr: bytes,
 
         ca_path = ca_pem
         if ca_path is None:
-            # Fetch FreeTSA's CA for offline-style verification of its tokens.
+            # Fetch FreeTSA's CA when no local CA was supplied. Offline
+            # verification (ca_pem provided) needs no network and no httpx.
+            import httpx
             try:
                 ca = httpx.get(FREETSA_CACERT_URL, timeout=15.0).content
                 ca_path = os.path.join(d, "cacert.pem")

--- a/sdk/air_blackbox/anchor/tsa.py
+++ b/sdk/air_blackbox/anchor/tsa.py
@@ -1,0 +1,134 @@
+"""RFC 3161 timestamp anchoring via the openssl CLI (no new Python deps).
+
+Key-agnostic by design (see ADR 0001): the TSA signs the head with ITS key,
+so our Ed25519-vs-Rekor incompatibility never enters the picture. Multiple TSA
+URLs are tried in order and the responder is recorded; an anchor that cannot be
+obtained is reported as a gap, never silently dropped.
+"""
+
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from typing import List, Optional
+
+import httpx
+
+# Public RFC 3161 timestamp authorities, tried in order.
+DEFAULT_TSA_URLS = [
+    "https://freetsa.org/tsr",
+    "https://timestamp.sigstore.dev/api/v1/timestamp",
+    "http://timestamp.digicert.com",
+]
+
+# CA cert chains for the TSAs above, for offline verification. FreeTSA's is the
+# one we bundle by default; operators can supply their own via ca_pem.
+FREETSA_CACERT_URL = "https://freetsa.org/files/cacert.pem"
+
+
+@dataclass
+class AnchorResult:
+    """The outcome of anchoring a head. On success, `tsr` is the DER RFC 3161
+    token and `tsa_url` names the responder; on failure, `error` explains the
+    gap (which the caller must record, not swallow)."""
+    ok: bool
+    head: str
+    tsr: Optional[bytes] = None
+    tsa_url: Optional[str] = None
+    timestamp: Optional[str] = None
+    error: Optional[str] = None
+
+
+def _openssl(args: List[str], stdin: Optional[bytes] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(["openssl"] + args, input=stdin,
+                          capture_output=True, timeout=30)
+
+
+def make_query(head_hex: str) -> bytes:
+    """Build an RFC 3161 timestamp query (TSQ) over a 32-byte head."""
+    with tempfile.TemporaryDirectory() as d:
+        out = os.path.join(d, "req.tsq")
+        r = _openssl(["ts", "-query", "-digest", head_hex, "-sha256",
+                      "-cert", "-out", out])
+        if r.returncode != 0:
+            raise RuntimeError(f"ts -query failed: {r.stderr.decode(errors='replace')}")
+        with open(out, "rb") as f:
+            return f.read()
+
+
+def timestamp_head(head_hex: str,
+                   tsa_urls: Optional[List[str]] = None) -> AnchorResult:
+    """Obtain an RFC 3161 timestamp over the head from the first reachable TSA."""
+    if not head_hex:
+        return AnchorResult(ok=False, head=head_hex, error="no chain head to anchor")
+    urls = tsa_urls or DEFAULT_TSA_URLS
+    try:
+        tsq = make_query(head_hex)
+    except Exception as e:  # noqa: BLE001 - report as a gap, never crash export
+        return AnchorResult(ok=False, head=head_hex, error=str(e))
+
+    last_err = "no TSA reachable"
+    for url in urls:
+        try:
+            resp = httpx.post(url, content=tsq, timeout=20.0,
+                              headers={"Content-Type": "application/timestamp-query"})
+        except httpx.HTTPError as e:
+            last_err = f"{url}: {e}"
+            continue
+        if resp.status_code != 200 or not resp.content:
+            last_err = f"{url}: HTTP {resp.status_code}"
+            continue
+        tsr = resp.content
+        ts = _extract_time(tsr)
+        return AnchorResult(ok=True, head=head_hex, tsr=tsr, tsa_url=url, timestamp=ts)
+
+    return AnchorResult(ok=False, head=head_hex, error=last_err)
+
+
+def _extract_time(tsr: bytes) -> Optional[str]:
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, "resp.tsr")
+        with open(p, "wb") as f:
+            f.write(tsr)
+        r = _openssl(["ts", "-reply", "-in", p, "-text"])
+        for line in r.stdout.decode(errors="replace").splitlines():
+            if line.strip().startswith("Time stamp:"):
+                return line.split("Time stamp:", 1)[1].strip()
+    return None
+
+
+def verify_anchor_bytes(head_hex: str, tsr: bytes,
+                        ca_pem: Optional[str] = None) -> tuple[bool, Optional[str]]:
+    """Verify a TSR commits to head_hex, against a TSA CA chain.
+
+    Returns (ok, detail). This is the operation that makes a rewritten history
+    detectable: recompute the current head, and if it differs from what the TSR
+    countersigned, verification fails with a message-imprint mismatch.
+    """
+    if not tsr:
+        return False, "no timestamp token"
+    with tempfile.TemporaryDirectory() as d:
+        tsr_path = os.path.join(d, "resp.tsr")
+        with open(tsr_path, "wb") as f:
+            f.write(tsr)
+
+        ca_path = ca_pem
+        if ca_path is None:
+            # Fetch FreeTSA's CA for offline-style verification of its tokens.
+            try:
+                ca = httpx.get(FREETSA_CACERT_URL, timeout=15.0).content
+                ca_path = os.path.join(d, "cacert.pem")
+                with open(ca_path, "wb") as f:
+                    f.write(ca)
+            except httpx.HTTPError as e:
+                return False, f"could not obtain TSA CA chain: {e}"
+
+        r = _openssl(["ts", "-verify", "-digest", head_hex, "-in", tsr_path,
+                      "-CAfile", ca_path, "-no_check_time"])
+        out = (r.stdout + r.stderr).decode(errors="replace")
+        if r.returncode == 0 and "Verification: OK" in out:
+            return True, "anchor commits to the current head"
+        if "message imprint mismatch" in out:
+            return False, "message imprint mismatch: the current head does not " \
+                          "match what the timestamp countersigned (history was rewritten)"
+        return False, out.strip().splitlines()[-1] if out.strip() else "verification failed"

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -56,8 +56,9 @@ While this connector is enabled you MUST:
    approved (e.g. "reject_candidate for Dana Okafor, approved by user").
 4. When unsure whether something is allowed, call check_covenant first.
 5. When the user asks for proof, a report, or an audit trail, call
-   verify_chain (records unaltered) and verify_receipts (who authorized
-   each action, via public-key signatures), then export_evidence.
+   verify_chain (records unaltered), verify_receipts (who authorized each
+   action), and verify_anchor (an external authority countersigned the
+   history, so even a re-signed rewrite is detectable), then export_evidence.
 
 This is not optional bookkeeping: the recorded chain is the user's
 compliance evidence. Unrecorded actions do not exist for audit purposes."""
@@ -413,6 +414,10 @@ def export_evidence() -> str:
     verification = engine.verify_chain()
     fully_intact = verification.intact and verification.verified_records == total
 
+    # Anchor the head at an external TSA BEFORE packaging, so the timestamp
+    # token travels inside the signed bundle (verifiable offline by a stranger).
+    anchor_note, anchor_manifest = _anchor_current_head(tenant)
+
     path = generate_evidence_zip(
         chain_entries=engine._raw_records,
         scan_results={"source": "air-blackbox MCP server", "tenant": tenant,
@@ -423,7 +428,10 @@ def export_evidence() -> str:
                       # Publish the receipt public key so a third party can
                       # verify every action's Ed25519 signature independently.
                       "receipt_signing_method": _tenant_signer(tenant).method,
-                      "receipt_public_key": _tenant_signer(tenant).public_key_hex or ""},
+                      "receipt_public_key": _tenant_signer(tenant).public_key_hex or "",
+                      # The external timestamp anchor (or a recorded gap), so the
+                      # bundle proves the head was bound at a past time.
+                      "anchor": anchor_manifest},
         signing_key=key, output_dir=runs)
 
     if not verification.intact:
@@ -439,7 +447,101 @@ def export_evidence() -> str:
                 f"{unchained} carry no chain hash. The manifest records this. "
                 f"Tell the user.")
     return (f"Evidence bundle written: {path} ({total} records, chain fully "
-            f"verified at export time; verification stamped into the manifest)")
+            f"verified at export time; verification stamped into the manifest). "
+            f"{anchor_note}")
+
+
+def _anchor_dir(tenant: str) -> str:
+    d = os.path.join(_tenant_runs_dir(tenant), "anchors")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _anchor_current_head(tenant: str):
+    """Timestamp the current chain head at an external TSA and persist the
+    token. An unreachable TSA is recorded as a gap, never silently dropped.
+    Returns (note, manifest_dict) - the manifest goes into the signed bundle."""
+    import base64
+    import json as _json
+
+    from air_blackbox.anchor import compute_head, timestamp_head
+
+    runs = _tenant_runs_dir(tenant)
+    engine = ReplayEngine(runs_dir=runs)
+    engine.load()
+    seq_max = max((r.get("chain_seq") or 0 for r in engine._raw_records), default=0)
+    head = compute_head(runs)
+    if not head:
+        return "Anchor: no chained records to anchor.", {"anchored": False,
+                                                         "reason": "no records"}
+
+    result = timestamp_head(head, _tsa_urls())
+    if not result.ok:
+        # An anchor gap is itself evidence - record it, do not hide it.
+        with open(os.path.join(_anchor_dir(tenant), "gaps.log"), "a") as f:
+            f.write(_json.dumps({"seq_max": seq_max, "head": head,
+                                 "error": result.error}) + "\n")
+        note = (f"Anchor: GAP - no external timestamp obtained ({result.error}). "
+                f"Recorded as a gap; the head is not externally bound this export.")
+        return note, {"anchored": False, "head": head, "seq_max": seq_max,
+                      "error": result.error}
+
+    manifest = {"anchored": True, "head": head, "seq_max": seq_max,
+                "tsa_url": result.tsa_url, "timestamp": result.timestamp,
+                "tsr_b64": base64.b64encode(result.tsr).decode()}
+    with open(os.path.join(_anchor_dir(tenant), f"anchor-{seq_max:012d}.json"), "w") as f:
+        _json.dump(manifest, f)
+    note = (f"Anchor: head bound to {result.tsa_url} at {result.timestamp}. "
+            f"A rewritten history cannot inherit this timestamp.")
+    return note, manifest
+
+
+def _tsa_urls():
+    urls = os.environ.get("AIR_TSA_URLS", "")
+    return [u.strip() for u in urls.split(",") if u.strip()] or None
+
+
+@app.tool()
+def verify_anchor() -> str:
+    """Verify the external timestamp anchor for this tenant.
+
+    verify_chain and verify_receipts prove records were not altered and who
+    signed them - but the operator holds those keys and could rewrite and
+    re-sign the whole history. This checks the RFC 3161 timestamp: an external
+    authority countersigned the chain head at a past time with a key the
+    operator does not control, so a rewritten head no longer matches it."""
+    import base64
+    import glob as _glob
+    import json as _json
+
+    from air_blackbox.anchor import compute_head, verify_anchor_bytes
+
+    tenant = _current_tenant()
+    anchors = sorted(_glob.glob(os.path.join(_anchor_dir(tenant), "anchor-*.json")))
+    if not anchors:
+        gaps = os.path.join(_anchor_dir(tenant), "gaps.log")
+        if os.path.exists(gaps):
+            return ("NO ANCHOR: the head has never been externally timestamped "
+                    "(anchor gaps recorded). Run export_evidence with a reachable "
+                    "TSA. Until then, a rewritten history would NOT be detectable "
+                    "by anchoring - tell the user.")
+        return "NO ANCHOR yet: run export_evidence to timestamp the chain head."
+
+    with open(anchors[-1]) as f:
+        m = _json.load(f)
+    tsr = base64.b64decode(m["tsr_b64"])
+    # Re-derive the head over exactly the records the anchor covered. A rewrite
+    # of any of those records changes this head and breaks the match.
+    head_now = compute_head(_tenant_runs_dir(tenant), up_to_seq=m["seq_max"])
+    ok, detail = verify_anchor_bytes(head_now, tsr, ca_pem=os.environ.get("AIR_TSA_CACERT"))
+    if ok:
+        return (f"ANCHOR VALID: an external authority ({m['tsa_url']}) "
+                f"countersigned this history's head at {m['timestamp']}. The "
+                f"records up to sequence {m['seq_max']} have not been rewritten "
+                f"since - verifiable by a third party against the TSA, no secret "
+                f"of ours required.")
+    return (f"ANCHOR BROKEN: {detail}. The history covered by the timestamp from "
+            f"{m['timestamp']} has been altered since it was anchored - tell the user.")
 
 
 @app.tool()

--- a/sdk/tests/test_anchor.py
+++ b/sdk/tests/test_anchor.py
@@ -149,6 +149,17 @@ def test_missing_token_is_a_gap_not_a_pass(tmp_path):
 
 
 # --- MCP integration: export_evidence anchors, verify_anchor detects rewrite ---
+# These need the MCP SDK; skip cleanly if it is not installed (the core anchor
+# tests above do not need it).
+
+def _mcp_server(monkeypatch, tmp_path):
+    pytest.importorskip("mcp")
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+    return srv
+
 
 def _patch_local_tsa(monkeypatch, tsa: "LocalTSA"):
     """Make the MCP server's anchor path use a local offline TSA."""
@@ -162,10 +173,7 @@ def _patch_local_tsa(monkeypatch, tsa: "LocalTSA"):
 
 
 def test_mcp_export_anchors_and_verify_anchor_passes(tmp_path, monkeypatch):
-    import air_blackbox.mcp_server as srv
-    monkeypatch.setattr(srv, "_covenant", None)
-    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
-    srv._chains.clear(); srv._signers.clear()
+    srv = _mcp_server(monkeypatch, tmp_path)
     tsa = LocalTSA(str(tmp_path / "tsa"))
     _patch_local_tsa(monkeypatch, tsa)
 
@@ -180,11 +188,8 @@ def test_mcp_export_anchors_and_verify_anchor_passes(tmp_path, monkeypatch):
 def test_mcp_rewrite_breaks_anchor_but_not_chain(tmp_path, monkeypatch):
     """Full-stack version of THE test through the MCP tools: after a rewrite,
     verify_chain and verify_receipts still pass, but verify_anchor breaks."""
-    import glob, json
-    import air_blackbox.mcp_server as srv
-    monkeypatch.setattr(srv, "_covenant", None)
-    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
-    srv._chains.clear(); srv._signers.clear()
+    import glob
+    srv = _mcp_server(monkeypatch, tmp_path)
     tsa = LocalTSA(str(tmp_path / "tsa"))
     _patch_local_tsa(monkeypatch, tsa)
 
@@ -212,10 +217,7 @@ def test_mcp_rewrite_breaks_anchor_but_not_chain(tmp_path, monkeypatch):
 
 
 def test_mcp_anchor_gap_is_reported_not_hidden(tmp_path, monkeypatch):
-    import air_blackbox.mcp_server as srv
-    monkeypatch.setattr(srv, "_covenant", None)
-    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
-    srv._chains.clear(); srv._signers.clear()
+    srv = _mcp_server(monkeypatch, tmp_path)
 
     # No reachable TSA -> anchor gap.
     monkeypatch.setattr("air_blackbox.anchor.timestamp_head",

--- a/sdk/tests/test_anchor.py
+++ b/sdk/tests/test_anchor.py
@@ -11,12 +11,11 @@ A local RFC 3161 TSA is stood up with openssl so these run offline / in CI.
 import os
 import shutil
 import subprocess
-import tempfile
 
 import pytest
 
 from air_blackbox.anchor import compute_head, verify_anchor_bytes
-from air_blackbox.anchor.tsa import make_query
+from air_blackbox.anchor.tsa import AnchorResult, make_query
 from air_blackbox.replay.engine import ReplayEngine
 from air_blackbox.trust.chain import AuditChain
 
@@ -153,14 +152,12 @@ def test_missing_token_is_a_gap_not_a_pass(tmp_path):
 
 def _patch_local_tsa(monkeypatch, tsa: "LocalTSA"):
     """Make the MCP server's anchor path use a local offline TSA."""
-    import air_blackbox.anchor.tsa as tsamod
-
     def fake_timestamp_head(head_hex, tsa_urls=None):
-        return tsamod.AnchorResult(ok=True, head=head_hex, tsr=tsa.reply(head_hex),
-                                   tsa_url="local-test-tsa", timestamp="T0")
-    # export_evidence imports timestamp_head from air_blackbox.anchor
-    import air_blackbox.anchor as anchormod
-    monkeypatch.setattr(anchormod, "timestamp_head", fake_timestamp_head)
+        return AnchorResult(ok=True, head=head_hex, tsr=tsa.reply(head_hex),
+                            tsa_url="local-test-tsa", timestamp="T0")
+    # export_evidence imports timestamp_head from air_blackbox.anchor at call
+    # time, so patch the attribute on that module by its string path.
+    monkeypatch.setattr("air_blackbox.anchor.timestamp_head", fake_timestamp_head)
     monkeypatch.setenv("AIR_TSA_CACERT", tsa.ca_pem)
 
 
@@ -216,14 +213,13 @@ def test_mcp_rewrite_breaks_anchor_but_not_chain(tmp_path, monkeypatch):
 
 def test_mcp_anchor_gap_is_reported_not_hidden(tmp_path, monkeypatch):
     import air_blackbox.mcp_server as srv
-    import air_blackbox.anchor as anchormod
     monkeypatch.setattr(srv, "_covenant", None)
     monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
     srv._chains.clear(); srv._signers.clear()
 
     # No reachable TSA -> anchor gap.
-    monkeypatch.setattr(anchormod, "timestamp_head",
-                        lambda h, u=None: anchormod.AnchorResult(
+    monkeypatch.setattr("air_blackbox.anchor.timestamp_head",
+                        lambda h, u=None: AnchorResult(
                             ok=False, head=h, error="no TSA reachable"))
     srv.record_action("read_profile")
     out = srv.export_evidence()

--- a/sdk/tests/test_anchor.py
+++ b/sdk/tests/test_anchor.py
@@ -1,0 +1,231 @@
+"""Tests for external anchoring (binding history, M1).
+
+The headline is test_rewrite_is_detected_by_anchor - the one test the whole
+milestone exists for: a rewritten, re-signed history passes chain verification
+but FAILS anchor verification, because the old timestamp countersigned the old
+head. Everything else supports it.
+
+A local RFC 3161 TSA is stood up with openssl so these run offline / in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from air_blackbox.anchor import compute_head, verify_anchor_bytes
+from air_blackbox.anchor.tsa import make_query
+from air_blackbox.replay.engine import ReplayEngine
+from air_blackbox.trust.chain import AuditChain
+
+if shutil.which("openssl") is None:  # pragma: no cover
+    pytest.skip("openssl not available", allow_module_level=True)
+
+
+class LocalTSA:
+    """A throwaway RFC 3161 TSA (CA + timestamping cert) for offline tests."""
+
+    def __init__(self, d: str):
+        self.dir = d
+        os.makedirs(d, exist_ok=True)
+        self.ca_pem = os.path.join(d, "ca.pem")
+        self._setup()
+
+    def _ossl(self, *args, **kw):
+        return subprocess.run(["openssl", *args], capture_output=True,
+                              cwd=self.dir, timeout=30, **kw)
+
+    def _setup(self):
+        self._ossl("req", "-x509", "-newkey", "ec",
+                   "-pkeyopt", "ec_paramgen_curve:P-256",
+                   "-keyout", "ca.key", "-out", "ca.pem", "-nodes",
+                   "-subj", "/CN=Test Root CA", "-days", "2")
+        self._ossl("req", "-newkey", "ec",
+                   "-pkeyopt", "ec_paramgen_curve:P-256",
+                   "-keyout", "tsa.key", "-out", "tsa.csr", "-nodes",
+                   "-subj", "/CN=Test TSA")
+        with open(os.path.join(self.dir, "tsa.ext"), "w") as f:
+            f.write("extendedKeyUsage=critical,timeStamping\n")
+        self._ossl("x509", "-req", "-in", "tsa.csr", "-CA", "ca.pem",
+                   "-CAkey", "ca.key", "-CAcreateserial", "-out", "tsa.pem",
+                   "-days", "2", "-extfile", "tsa.ext")
+        with open(os.path.join(self.dir, "tsa.conf"), "w") as f:
+            f.write(
+                "[tsa]\ndefault_tsa = c\n[c]\nserial = ./serial\n"
+                "crypto_device = builtin\nsigner_cert = ./tsa.pem\n"
+                "certs = ./ca.pem\nsigner_key = ./tsa.key\nsigner_digest = sha256\n"
+                "default_policy = 1.2.3.4.1\ndigests = sha256, sha384, sha512\n"
+                "accuracy = secs:1\nordering = yes\ntsa_name = yes\n"
+                "ess_cert_id_chain = no\n")
+        with open(os.path.join(self.dir, "serial"), "w") as f:
+            f.write("01\n")
+
+    def reply(self, head_hex: str) -> bytes:
+        """Countersign a head, returning the DER RFC 3161 token."""
+        with open(os.path.join(self.dir, "req.tsq"), "wb") as f:
+            f.write(make_query(head_hex))
+        self._ossl("ts", "-reply", "-config", "tsa.conf",
+                   "-queryfile", "req.tsq", "-out", "resp.tsr")
+        with open(os.path.join(self.dir, "resp.tsr"), "rb") as f:
+            return f.read()
+
+
+def _write_chain(runs_dir, key, actions):
+    chain = AuditChain(runs_dir=runs_dir, signing_key=key)
+    for i, action in enumerate(actions):
+        chain.write({
+            "run_id": f"00000000-0000-0000-0000-{i:012d}",
+            "action": action, "status": "success",
+            "timestamp": f"2026-07-17T00:00:{i:02d}Z",
+        })
+
+
+def test_head_is_deterministic_and_chain_bound(tmp_path):
+    d = str(tmp_path / "runs"); os.makedirs(d)
+    _write_chain(d, "k", ["read_profile", "draft_message", "send_message"])
+    h1 = compute_head(d)
+    assert h1 and len(h1) == 64
+    assert compute_head(d) == h1                 # deterministic
+
+    # The head binds to the chain (chain_hash per record), so re-signing a
+    # different history - the exact thing an operator rewrite does - changes
+    # the head. (A content edit that leaves a stale chain_hash is caught by
+    # verify_chain instead; the head's job is to bind add/remove/re-sign.)
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    _write_chain(d, "k", ["read_profile", "draft_message", "block_send"])
+    assert compute_head(d) != h1
+
+
+def test_anchor_verifies_against_its_head(tmp_path):
+    d = str(tmp_path / "runs"); os.makedirs(d)
+    _write_chain(d, "k", ["read_profile", "send_message"])
+    head = compute_head(d)
+
+    tsa = LocalTSA(str(tmp_path / "tsa"))
+    tsr = tsa.reply(head)
+
+    ok, detail = verify_anchor_bytes(head, tsr, ca_pem=tsa.ca_pem)
+    assert ok, detail
+
+
+def test_rewrite_is_detected_by_anchor(tmp_path):
+    """THE test. Anchor a history, then rewrite and re-sign it. The chain still
+    verifies (operator holds the key), but the anchor does not: the old
+    timestamp countersigned the old head."""
+    d = str(tmp_path / "runs"); os.makedirs(d)
+    key = "operator-key"
+    _write_chain(d, key, ["read_profile", "advance_candidate", "send_offer"])
+
+    head = compute_head(d)
+    tsa = LocalTSA(str(tmp_path / "tsa"))
+    tsr = tsa.reply(head)                          # anchored at time T
+    assert verify_anchor_bytes(head, tsr, ca_pem=tsa.ca_pem)[0]
+
+    # The operator rewrites history: same key, but "send_offer" becomes
+    # "reject_candidate" and a step is dropped. Rebuild the whole chain.
+    for f in os.listdir(d):
+        os.remove(os.path.join(d, f))
+    _write_chain(d, key, ["read_profile", "reject_candidate"])
+
+    # The rewritten chain verifies cleanly - this is the operator's forgery.
+    engine = ReplayEngine(runs_dir=d)
+    engine.load()
+    assert engine.verify_chain(signing_key=key).intact, \
+        "rewritten chain should pass chain verification (operator re-signed it)"
+
+    # But the anchor does not: the current head no longer matches the token.
+    new_head = compute_head(d)
+    assert new_head != head
+    ok, detail = verify_anchor_bytes(new_head, tsr, ca_pem=tsa.ca_pem)
+    assert not ok
+    assert "imprint mismatch" in detail or "rewritten" in detail
+
+
+def test_missing_token_is_a_gap_not_a_pass(tmp_path):
+    ok, detail = verify_anchor_bytes("deadbeef" * 8, b"", ca_pem=None)
+    assert not ok and "no timestamp token" in detail
+
+
+# --- MCP integration: export_evidence anchors, verify_anchor detects rewrite ---
+
+def _patch_local_tsa(monkeypatch, tsa: "LocalTSA"):
+    """Make the MCP server's anchor path use a local offline TSA."""
+    import air_blackbox.anchor.tsa as tsamod
+
+    def fake_timestamp_head(head_hex, tsa_urls=None):
+        return tsamod.AnchorResult(ok=True, head=head_hex, tsr=tsa.reply(head_hex),
+                                   tsa_url="local-test-tsa", timestamp="T0")
+    # export_evidence imports timestamp_head from air_blackbox.anchor
+    import air_blackbox.anchor as anchormod
+    monkeypatch.setattr(anchormod, "timestamp_head", fake_timestamp_head)
+    monkeypatch.setenv("AIR_TSA_CACERT", tsa.ca_pem)
+
+
+def test_mcp_export_anchors_and_verify_anchor_passes(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+    tsa = LocalTSA(str(tmp_path / "tsa"))
+    _patch_local_tsa(monkeypatch, tsa)
+
+    srv.record_action("read_profile")
+    srv.record_action("advance_candidate")
+    out = srv.export_evidence()
+    assert "Anchor: head bound to" in out
+
+    assert "ANCHOR VALID" in srv.verify_anchor()
+
+
+def test_mcp_rewrite_breaks_anchor_but_not_chain(tmp_path, monkeypatch):
+    """Full-stack version of THE test through the MCP tools: after a rewrite,
+    verify_chain and verify_receipts still pass, but verify_anchor breaks."""
+    import glob, json
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+    tsa = LocalTSA(str(tmp_path / "tsa"))
+    _patch_local_tsa(monkeypatch, tsa)
+
+    srv.record_action("read_profile")
+    srv.record_action("advance_candidate")
+    srv.export_evidence()                       # anchors head at seq 2
+    assert "ANCHOR VALID" in srv.verify_anchor()
+
+    # Operator rewrites history: rebuild the two records with a changed action,
+    # re-signing the chain and re-signing the receipts with the tenant's keys.
+    runs = str(tmp_path)
+    for f in glob.glob(os.path.join(runs, "*.air.json")):
+        os.remove(f)
+    srv._chains.clear()                         # fresh chain over the same store
+    srv.record_action("read_profile")
+    srv.record_action("reject_candidate")       # the forged outcome
+
+    # The rewritten chain and receipts verify cleanly - the operator holds the keys.
+    assert "CHAIN INTACT" in srv.verify_chain()
+    assert "ALL RECEIPTS VALID" in srv.verify_receipts()
+
+    # But the anchor does not: the countersigned head no longer matches.
+    out = srv.verify_anchor()
+    assert "ANCHOR BROKEN" in out
+
+
+def test_mcp_anchor_gap_is_reported_not_hidden(tmp_path, monkeypatch):
+    import air_blackbox.mcp_server as srv
+    import air_blackbox.anchor as anchormod
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear(); srv._signers.clear()
+
+    # No reachable TSA -> anchor gap.
+    monkeypatch.setattr(anchormod, "timestamp_head",
+                        lambda h, u=None: anchormod.AnchorResult(
+                            ok=False, head=h, error="no TSA reachable"))
+    srv.record_action("read_profile")
+    out = srv.export_evidence()
+    assert "Anchor: GAP" in out
+    assert "NO ANCHOR" in srv.verify_anchor()


### PR DESCRIPTION
## What does this PR do?
Implements **M1** of the binding-history roadmap: anchor the chain head to an external RFC 3161 timestamp authority on every evidence export, so a rewritten-and-re-signed history is detectable.

**The problem it closes:** AIR proves nothing was *altered*, but the operator holds the chain (HMAC) and receipt (Ed25519) keys — so they could rewrite the whole history, re-sign it, and both `verify_chain` and `verify_receipts` would still pass. Anchoring the head to a timestamp authority — a key the operator does **not** control — means a rewritten head no longer matches its old countersignature. The claim this enables: *"you can still lie, but not invisibly."*

**What's here:**
- `air_blackbox.anchor` — a **key-free chain head** (SHA-256 over the ordered `(chain_seq, chain_hash)` pairs, computable by anyone with the records and no secret), plus RFC 3161 request/verify via the `openssl` CLI. Key-agnostic per [ADR 0001](docs/decisions/0001-anchor-rail.md), so our Ed25519↔Rekor incompatibility never enters the picture. Multiple TSA endpoints tried in order; no new Python dependencies.
- `export_evidence` anchors the head **before** packaging and embeds the RFC 3161 token in the signed bundle. An unreachable TSA is recorded as an **anchor gap** — never silently dropped.
- New MCP tool **`verify_anchor`** — re-derives the head over the anchored sequence range and checks the timestamp, detecting a rewrite of past records while letting later records legitimately advance the head.

**The one test that matters** (`test_rewrite_is_detected_by_anchor`, plus its full-stack MCP twin `test_mcp_rewrite_breaks_anchor_but_not_chain`): a rewritten, re-signed history passes `verify_chain` **and** `verify_receipts` but **fails** `verify_anchor` with a message-imprint mismatch. A local `openssl` TSA makes it run offline / in CI. Proven end to end in this session — chain INTACT, receipts VALID, anchor BROKEN after a rewrite.

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] New compliance check
- [x] Trust layer integration

## EU AI Act articles affected
Article 12 (record-keeping): raises the audit trail from tamper-evident to rewrite-detectable, an operator-independent integrity guarantee.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass (149 Python tests; new anchor suite included)
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility (additive; anchoring is best-effort, records gain nothing, gap is recorded when no TSA)

## Additional notes
Follows the M0 spike ([ADR 0001](docs/decisions/0001-anchor-rail.md)): M1 uses RFC 3161 TSA (key-agnostic), M2 will add Rekor with a dedicated ECDSA anchor key. No new dependencies (`httpx` already required, `openssl` is a system binary). Recommend **squash merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_