### PR TITLE
fix(deploy): load the recruiting-screener covenant on the remote MCP server

### DIFF
--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -24,7 +24,7 @@ primary_region = "iad"
   # Hosts the server trusts (DNS-rebinding protection). Include the raw
   # fly.dev hostname so you can test before the custom domain is wired.
   AIR_MCP_ALLOWED_HOSTS = "air-mcp.fly.dev,mcp.airblackbox.ai"
-  # AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
+  AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
   #
   # OAuth (resource-server). Production: point at your IdP's introspection
   # endpoint so claude.ai tokens are verified per request and tenants isolate


### PR DESCRIPTION
The fly deployment shipped with `AIR_COVENANT` commented out, so the remote connector at air-mcp.fly.dev ran **unrestricted** — no approval gates, no forbidden actions. The covenant file already ships in the image (`COPY sdk/ sdk/`); this uncomments the env var to turn it on.

Verified live: after deploying with this change, `check_covenant` through the remote connector returns `reject_candidate → require_approval`, `infer_protected_attributes → forbid`, `read_profile → permit`.

Note: cherry-picked onto current main — the original deploy branch (`claude/mcp-deploy-hostfix`) predates #43/#44 and should not be merged (it would remove the anchor feature). After this merges, the fly app should be redeployed from main so the live server picks up #43/#44 as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)