### PR TITLE
Evidence Bundle v1: structured, signed, SB 24-205-mappable export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ all = [
 air-blackbox = "air_blackbox.cli:main"
 air-blackbox-comply-strict = "air_blackbox.precommit:main"
 air-blackbox-mcp = "air_blackbox.mcp_server:main"
+air-evidence = "air_blackbox.evidence_verify:main"
 
 [project.urls]
 Homepage = "https://airblackbox.ai"
@@ -78,6 +79,9 @@ Issues = "https://github.com/airblackbox/airblackbox/issues"
 
 [tool.setuptools.packages.find]
 where = ["sdk"]
+
+[tool.setuptools.package-data]
+air_blackbox = ["export/mappings/*.json", "gate/examples/*.yaml"]
 
 [tool.setuptools.package-dir]
 "" = "sdk"

--- a/sdk/air_blackbox/evidence_verify.py
+++ b/sdk/air_blackbox/evidence_verify.py
@@ -1,0 +1,284 @@
+"""air-evidence: independent verifier for .air-evidence v1 bundles.
+
+    air-evidence verify bundle.air-evidence [--key HMAC_KEY]
+
+Runs five checks in order, failing loudly with the exact record id on the
+first failure:
+
+  1. ZIP integrity and required files present
+  2. Manifest signature valid against the bundled public key (and the
+     manifest's per-file digests match the actual bundle contents, so the
+     one signature transitively covers every file)
+  3. Chain hashes consistent over records/actions.jsonl (full HMAC
+     recompute when --key is provided; structural consistency otherwise)
+  4. Every record's receipt signature verifies with the public key
+  5. Counts in the manifest match the actual records
+
+No secrets are required for checks 1, 2, 4, and 5 - a client's lawyer,
+their enterprise customer, or a regulator can run this as-is. The --key
+option additionally recomputes the private HMAC chain.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac as hmac_mod
+import json
+import sys
+import zipfile
+from typing import Any, Dict, List
+
+from air_blackbox.export.evidence_bundle import (
+    V1_REQUIRED_FILES,
+    canonical_manifest_bytes,
+    categorize_record,
+)
+
+
+class VerificationFailure(Exception):
+    def __init__(self, check: int, message: str):
+        super().__init__(message)
+        self.check = check
+        self.message = message
+
+
+def _fail(check: int, message: str) -> None:
+    raise VerificationFailure(check, message)
+
+
+def _read(zf: zipfile.ZipFile, name: str) -> bytes:
+    with zf.open(name) as f:
+        return f.read()
+
+
+def _ed25519_verify(public_key_raw: bytes, signature_hex: str,
+                    data: bytes) -> bool:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PublicKey,
+    )
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key_raw).verify(
+            bytes.fromhex(signature_hex), data)
+        return True
+    except Exception:
+        return False
+
+
+def _pem_raw_key(pem_text: str) -> bytes:
+    """Extract the raw Ed25519 key bytes from the bundled PEM."""
+    from cryptography.hazmat.primitives import serialization
+    key = serialization.load_pem_public_key(pem_text.encode())
+    return key.public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+
+
+def _auth_payload(receipt: Dict[str, Any]) -> bytes:
+    """Rebuild ActionReceipt.authorization_payload byte-for-byte."""
+    data = {
+        "receipt_id": receipt.get("receipt_id", ""),
+        "agent_id": receipt.get("agent_id", ""),
+        "action_name": receipt.get("action_name", ""),
+        "action_category": receipt.get("action_category", ""),
+        "payload_hash": receipt.get("payload_hash", ""),
+        "covenant_hash": receipt.get("covenant_hash", ""),
+        "decision": receipt.get("decision", ""),
+        "authorized": receipt.get("authorized", False),
+        "parent_receipt_id": receipt.get("parent_receipt_id"),
+        "created_at": receipt.get("created_at", ""),
+    }
+    return json.dumps(data, sort_keys=True).encode("utf-8")
+
+
+def verify_bundle(path: str, hmac_key: str | None = None,
+                  out=sys.stdout) -> Dict[str, Any]:
+    """Run all five checks. Returns a summary dict; raises
+    VerificationFailure on the first failed check."""
+
+    # ---- Check 1: ZIP integrity and required files ------------------------
+    try:
+        zf = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as e:
+        _fail(1, f"cannot open bundle: {e}")
+    bad = zf.testzip()
+    if bad is not None:
+        _fail(1, f"corrupt member in ZIP: {bad}")
+    names = set(zf.namelist())
+    missing = [n for n in V1_REQUIRED_FILES if n not in names]
+    if missing:
+        _fail(1, f"required files missing from bundle: {', '.join(missing)}")
+    print("[1/5] ZIP integrity and layout: OK", file=out)
+
+    # ---- Check 2: manifest signature + per-file digests -------------------
+    try:
+        manifest = json.loads(_read(zf, "manifest.json"))
+    except json.JSONDecodeError as e:
+        _fail(2, f"manifest.json is not valid JSON: {e}")
+    sig = manifest.get("signature") or {}
+    digest = hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+    if digest != sig.get("signed_digest"):
+        _fail(2, "manifest digest mismatch: canonical sha256 is "
+                 f"{digest[:16]}..., manifest claims "
+                 f"{str(sig.get('signed_digest'))[:16]}... - the manifest "
+                 "was altered after signing")
+    pem_text = _read(zf, "verification/public_key.pem").decode()
+    alg = sig.get("alg", "")
+    if alg == "ed25519":
+        try:
+            pub_raw = _pem_raw_key(pem_text)
+        except Exception as e:
+            _fail(2, f"cannot parse verification/public_key.pem: {e}")
+        if sig.get("public_key_hex") and pub_raw.hex() != sig["public_key_hex"]:
+            _fail(2, "public key mismatch: manifest signature key != "
+                     "verification/public_key.pem")
+        if not _ed25519_verify(pub_raw, sig.get("value", ""),
+                               bytes.fromhex(digest)):
+            _fail(2, "manifest signature INVALID for the bundled public key")
+    elif alg == "hmac-sha256":
+        if not hmac_key:
+            _fail(2, "manifest is HMAC-signed; pass --key to verify "
+                     "(no public-key signature present)")
+        expect = hmac_mod.new(hmac_key.encode(), bytes.fromhex(digest),
+                              hashlib.sha256).hexdigest()
+        if not hmac_mod.compare_digest(expect, sig.get("value", "")):
+            _fail(2, "manifest HMAC signature INVALID for the provided key")
+    else:
+        _fail(2, f"unsupported manifest signature algorithm: '{alg}'")
+    for fname, want in (manifest.get("files") or {}).items():
+        if fname not in names:
+            _fail(2, f"manifest lists {fname} but it is not in the bundle")
+        got = hashlib.sha256(_read(zf, fname)).hexdigest()
+        if got != want:
+            _fail(2, f"file digest mismatch for {fname}: contents were "
+                     "altered after the manifest was signed")
+    print(f"[2/5] Manifest signature ({alg}) and "
+          f"{len(manifest.get('files') or {})} file digests: OK", file=out)
+
+    # ---- Check 3: chain hashes over records/actions.jsonl -----------------
+    records: List[Dict[str, Any]] = []
+    for i, line in enumerate(
+            _read(zf, "records/actions.jsonl").decode().splitlines()):
+        if not line.strip():
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            _fail(3, f"records/actions.jsonl line {i + 1} is not valid JSON")
+    chain_doc = json.loads(_read(zf, "verification/chain.json"))
+    listed = chain_doc.get("records", [])
+    if len(listed) != len(records):
+        _fail(3, f"chain.json lists {len(listed)} records but "
+                 f"actions.jsonl contains {len(records)}")
+    for i, (rec, entry) in enumerate(zip(records, listed)):
+        if rec.get("run_id") != entry.get("run_id"):
+            _fail(3, f"record order mismatch at index {i}: actions.jsonl "
+                     f"run_id={rec.get('run_id')} vs chain.json "
+                     f"run_id={entry.get('run_id')}")
+        if rec.get("chain_hash") != entry.get("chain_hash"):
+            _fail(3, f"chain hash mismatch at index {i} "
+                     f"(run_id={rec.get('run_id')})")
+    if hmac_key:
+        prev = b"genesis"
+        for i, rec in enumerate(records):
+            body = {k: v for k, v in rec.items() if k != "chain_hash"}
+            h = hmac_mod.new(hmac_key.encode(),
+                             prev + json.dumps(body, sort_keys=True).encode(),
+                             hashlib.sha256)
+            if h.hexdigest() != rec.get("chain_hash"):
+                _fail(3, f"HMAC chain recompute FAILED at index {i} "
+                         f"(run_id={rec.get('run_id')}) - this record or an "
+                         "earlier one was altered")
+            prev = h.digest()
+        print(f"[3/5] Chain: full HMAC recompute over {len(records)} "
+              f"records: OK", file=out)
+    else:
+        print(f"[3/5] Chain: {len(records)} records structurally consistent "
+              f"with chain.json (pass --key for full HMAC recompute)",
+              file=out)
+
+    # ---- Check 4: per-record receipts -------------------------------------
+    checked = 0
+    for i, rec in enumerate(records):
+        receipt = rec.get("receipt")
+        if not receipt:
+            continue
+        method = receipt.get("signing_method", "")
+        sig_hex = receipt.get("authorization_sig", "")
+        if method == "ed25519":
+            pub_hex = receipt.get("signing_public_key", "")
+            if not pub_hex or not sig_hex:
+                _fail(4, f"receipt at index {i} (run_id={rec.get('run_id')}) "
+                         "lacks a key or signature")
+            if not _ed25519_verify(bytes.fromhex(pub_hex), sig_hex,
+                                   _auth_payload(receipt)):
+                _fail(4, f"receipt signature INVALID at index {i} "
+                         f"(run_id={rec.get('run_id')})")
+        elif method == "hmac-sha256":
+            if not hmac_key:
+                _fail(4, f"receipt at index {i} (run_id={rec.get('run_id')}) "
+                         "is HMAC-signed; pass --key to verify")
+            expect = hmac_mod.new(hmac_key.encode(), _auth_payload(receipt),
+                                  hashlib.sha256).hexdigest()
+            if not hmac_mod.compare_digest(expect, sig_hex):
+                _fail(4, f"receipt HMAC INVALID at index {i} "
+                         f"(run_id={rec.get('run_id')})")
+        else:
+            _fail(4, f"receipt at index {i} (run_id={rec.get('run_id')}) has "
+                     f"unsupported signing method '{method}'")
+        checked += 1
+    print(f"[4/5] Receipts: {checked}/{len(records)} records carry a "
+          f"receipt, all signatures valid", file=out)
+
+    # ---- Check 5: manifest counts match reality ---------------------------
+    cats = [categorize_record(r) for r in records]
+    screening = [r for r, c in zip(records, cats) if c == "screening_decision"]
+    actual = {
+        "actions": len(records),
+        "screening_decisions": len(screening),
+        "blocked_actions": cats.count("blocked_action"),
+        "human_approvals": cats.count("human_approval"),
+        "screening_decisions_missing_reviewer": sum(
+            1 for r in screening
+            if not r.get("screening", {}).get("human_reviewer")),
+    }
+    declared = manifest.get("counts") or {}
+    for k, v in actual.items():
+        if k in declared and declared[k] != v:
+            _fail(5, f"count mismatch for '{k}': manifest says "
+                     f"{declared[k]}, records show {v}")
+    print("[5/5] Counts: manifest matches records", file=out)
+
+    pub_hex = (manifest.get("signature") or {}).get("public_key_hex", "")
+    fingerprint = (
+        f"{alg}:{hashlib.sha256(bytes.fromhex(pub_hex)).hexdigest()[:16]}"
+        if pub_hex else alg)
+    return {"records": len(records), "alterations": 0,
+            "fingerprint": fingerprint, "counts": actual,
+            "bundle_id": manifest.get("bundle_id", "")}
+
+
+def main(argv: List[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="air-evidence",
+        description="Verify a .air-evidence bundle. No secrets required "
+                    "(--key optionally adds the private HMAC chain recompute).")
+    sub = ap.add_subparsers(dest="command", required=True)
+    vp = sub.add_parser("verify", help="verify a bundle")
+    vp.add_argument("bundle", help="path to the .air-evidence file")
+    vp.add_argument("--key", default=None,
+                    help="HMAC signing key for full chain recompute")
+    args = ap.parse_args(argv)
+
+    try:
+        summary = verify_bundle(args.bundle, hmac_key=args.key)
+    except VerificationFailure as e:
+        print(f"FAILED at check {e.check}: {e.message}", file=sys.stderr)
+        return 1
+    print(f"VERIFIED: {summary['records']} records, "
+          f"{summary['alterations']} alterations, "
+          f"signed by {summary['fingerprint']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdk/air_blackbox/export/evidence_bundle.py
+++ b/sdk/air_blackbox/export/evidence_bundle.py
@@ -16,11 +16,22 @@ import hmac
 import json
 import logging
 import os
+import uuid
 import zipfile
-from datetime import datetime
-from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
+
+#: Required members of a v1 .air-evidence bundle (attachments are optional).
+V1_REQUIRED_FILES = (
+    "manifest.json",
+    "records/actions.jsonl",
+    "verification/chain.json",
+    "verification/receipts.json",
+    "verification/public_key.pem",
+    "mapping/sb24-205.json",
+)
 
 
 def generate_evidence_zip(
@@ -88,6 +99,243 @@ def generate_evidence_zip(
 
     logger.info("evidence_bundle_generated path=%s entries=%d", zip_path, len(chain_entries))
     return os.path.abspath(zip_path)
+
+
+# ---------------------------------------------------------------------------
+# Evidence Bundle v1 (.air-evidence) - structured, signed, regulator-mappable.
+# Layout per the AIR Evidence Bundle v1 spec:
+#   manifest.json  records/actions.jsonl  verification/{chain,receipts}.json
+#   verification/public_key.pem  mapping/sb24-205.json  attachments/*
+# ---------------------------------------------------------------------------
+
+#: Screening actions: records with these action names (or an explicit
+#: "screening" object) evidence consequential decisions under SB 24-205.
+_SCREENING_ACTIONS = frozenset(
+    {"advance_candidate", "reject_candidate", "score_candidate",
+     "rank_candidates", "schedule_interview"})
+
+
+def categorize_record(record: Dict[str, Any]) -> str:
+    """Map a chained record to its evidence category (see mapping/*.json)."""
+    if record.get("status") == "blocked":
+        return "blocked_action"
+    action = record.get("action", "")
+    if action == "human_approval":
+        return "human_approval"
+    if "screening" in record or action in _SCREENING_ACTIONS:
+        return "screening_decision"
+    return "agent_action"
+
+
+def canonical_manifest_bytes(manifest: Dict[str, Any]) -> bytes:
+    """Canonical byte form of the manifest for signing: signature field
+    removed, keys sorted, no whitespace. Sign the sha256 of THIS, never the
+    pretty-printed JSON."""
+    stripped = {k: v for k, v in manifest.items() if k != "signature"}
+    return json.dumps(stripped, sort_keys=True,
+                      separators=(",", ":")).encode("utf-8")
+
+
+def _pem_public_key(public_key_hex: str) -> str:
+    """Render a raw Ed25519 public key as SubjectPublicKeyInfo PEM so the
+    verifier needs no secret and no custom parsing."""
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PublicKey,
+        )
+        key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key_hex))
+        return key.public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+    except Exception:
+        # HMAC-fallback signers have no public key; ship the hex (possibly
+        # empty) with an explanatory header so the bundle stays well-formed.
+        return ("-----BEGIN AIR PUBLIC KEY HEX-----\n"
+                f"{public_key_hex}\n"
+                "-----END AIR PUBLIC KEY HEX-----\n")
+
+
+def _retention_until(created: datetime, years: int = 3) -> str:
+    """SB 24-205 retention floor: created + 3 years (Feb 29 clamps to 28)."""
+    try:
+        return created.replace(year=created.year + years).date().isoformat()
+    except ValueError:
+        return created.replace(year=created.year + years,
+                               day=28).date().isoformat()
+
+
+def _load_framework_mapping(name: str) -> str:
+    path = os.path.join(os.path.dirname(__file__), "mappings", f"{name}.json")
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def generate_evidence_bundle_v1(
+    chain_entries: List[Dict[str, Any]],
+    tenant: str,
+    signer,
+    chain_verification: Dict[str, Any],
+    system: Optional[Dict[str, Any]] = None,
+    attachments_dir: Optional[str] = None,
+    anchor_manifest: Optional[Dict[str, Any]] = None,
+    output_dir: str = ".",
+) -> Tuple[str, Dict[str, Any]]:
+    """Generate a v1 .air-evidence bundle and return (path, manifest).
+
+    Args:
+        chain_entries: chained records in write order (each carries
+                       chain_hash and, normally, a signed receipt).
+        tenant: tenant id the records belong to.
+        signer: ReceiptSigner for the tenant - signs the manifest with the
+                same key that signed the per-record receipts.
+        chain_verification: verify_chain result stamped into the bundle.
+        system: deployer-supplied system register info (name,
+                high_risk_rationale, deployer). Missing values are recorded
+                as "deployer-supplied" so gaps are explicit, never hidden.
+        attachments_dir: directory of deployer documents (impact assessment,
+                         system register, monitoring plan) copied under
+                         attachments/.
+        anchor_manifest: external timestamp anchor manifest, if anchoring ran.
+        output_dir: where to write the bundle.
+    """
+    now = datetime.now(timezone.utc)
+    created_at = now.isoformat(timespec="seconds").replace("+00:00", "Z")
+
+    # --- records/actions.jsonl: one canonical line per record, chain order.
+    actions_jsonl = "\n".join(
+        json.dumps(r, sort_keys=True, default=str) for r in chain_entries)
+    if actions_jsonl:
+        actions_jsonl += "\n"
+
+    # --- counts (screening decisions missing a reviewer are themselves
+    # assessment output: the gap is reported, not hidden).
+    cats = [categorize_record(r) for r in chain_entries]
+    screening_records = [r for r, c in zip(chain_entries, cats)
+                         if c == "screening_decision"]
+    missing_reviewer = sum(
+        1 for r in screening_records
+        if not r.get("screening", {}).get("human_reviewer"))
+    counts = {
+        "actions": len(chain_entries),
+        "screening_decisions": len(screening_records),
+        "blocked_actions": cats.count("blocked_action"),
+        "human_approvals": cats.count("human_approval"),
+        "screening_decisions_missing_reviewer": missing_reviewer,
+    }
+
+    # --- verification/chain.json
+    timestamps = [r.get("timestamp", "") for r in chain_entries
+                  if r.get("timestamp")]
+    chain_doc = json.dumps({
+        "algorithm": ("HMAC-SHA256(key, prev_hash || "
+                      "json.dumps(record_without_chain_hash, sort_keys=True)); "
+                      "prev_hash starts at b'genesis' and advances to the raw "
+                      "digest each step"),
+        "head_hash": (chain_entries[-1].get("chain_hash", "")
+                      if chain_entries else ""),
+        "records": [{"run_id": r.get("run_id", ""),
+                     "chain_hash": r.get("chain_hash", "")}
+                    for r in chain_entries],
+        "verification_at_export": chain_verification,
+    }, indent=2, default=str)
+
+    # --- verification/receipts.json
+    receipts_doc = json.dumps({
+        "signing_method": signer.method,
+        "public_key_hex": signer.public_key_hex or "",
+        "note": ("Each receipt's authorization_sig covers the canonical "
+                 "authorization payload (receipt_id, agent_id, action_name, "
+                 "action_category, payload_hash, covenant_hash, decision, "
+                 "authorized, parent_receipt_id, created_at) serialized with "
+                 "sort_keys=True. Verifiable with the public key alone."),
+        "receipts": [{"run_id": r.get("run_id", ""), **r["receipt"]}
+                     for r in chain_entries if r.get("receipt")],
+    }, indent=2, default=str)
+
+    public_key_pem = _pem_public_key(signer.public_key_hex or "")
+    mapping_doc = _load_framework_mapping("sb24-205")
+
+    # --- attachments (deployer-supplied documents ride along, digested and
+    # therefore covered by the manifest signature).
+    attachments: Dict[str, bytes] = {}
+    if attachments_dir and os.path.isdir(attachments_dir):
+        for fname in sorted(os.listdir(attachments_dir)):
+            fpath = os.path.join(attachments_dir, fname)
+            if os.path.isfile(fpath) and not fname.startswith("."):
+                with open(fpath, "rb") as f:
+                    attachments[f"attachments/{fname}"] = f.read()
+
+    # --- manifest: every bundle file is digested here, so the single
+    # manifest signature transitively covers the entire bundle.
+    files: Dict[str, str] = {
+        "records/actions.jsonl": hashlib.sha256(
+            actions_jsonl.encode()).hexdigest(),
+        "verification/chain.json": hashlib.sha256(
+            chain_doc.encode()).hexdigest(),
+        "verification/receipts.json": hashlib.sha256(
+            receipts_doc.encode()).hexdigest(),
+        "verification/public_key.pem": hashlib.sha256(
+            public_key_pem.encode()).hexdigest(),
+        "mapping/sb24-205.json": hashlib.sha256(
+            mapping_doc.encode()).hexdigest(),
+    }
+    for name, blob in attachments.items():
+        files[name] = hashlib.sha256(blob).hexdigest()
+
+    system = dict(system or {})
+    manifest: Dict[str, Any] = {
+        "bundle_version": "1.0",
+        "bundle_id": str(uuid.uuid4()),
+        "created_at": created_at,
+        "tenant": tenant,
+        "system": {
+            "name": system.get("name") or "deployer-supplied",
+            "high_risk_rationale": (system.get("high_risk_rationale")
+                                    or "deployer-supplied"),
+            "deployer": system.get("deployer") or "deployer-supplied",
+            "period_covered": {
+                "from": min(timestamps) if timestamps else "",
+                "to": max(timestamps) if timestamps else "",
+            },
+        },
+        "counts": counts,
+        "retention_until": _retention_until(now),
+        "retention_note": ("SB 24-205 requires retention for 3 years after "
+                           "the system is discontinued; this date assumes "
+                           "discontinuation no earlier than export."),
+        "frameworks": ["CO-SB24-205"],
+        "outcome_monitoring": "deployer-supplied",
+        "anchor": anchor_manifest or {"status": "absent"},
+        "files": files,
+    }
+
+    digest = hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+    manifest["signature"] = {
+        "alg": signer.method,
+        "upgrade_path": "ML-DSA-65",
+        "signed_digest": digest,
+        "encoding": "hex",
+        "value": signer.sign(bytes.fromhex(digest)),
+        "public_key_hex": signer.public_key_hex or "",
+    }
+
+    bundle_name = f"bundle-{now.strftime('%Y-%m-%d-%H%M%S')}-{tenant}.air-evidence"
+    path = os.path.join(output_dir, bundle_name)
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+        zf.writestr("records/actions.jsonl", actions_jsonl)
+        zf.writestr("verification/chain.json", chain_doc)
+        zf.writestr("verification/receipts.json", receipts_doc)
+        zf.writestr("verification/public_key.pem", public_key_pem)
+        zf.writestr("mapping/sb24-205.json", mapping_doc)
+        for name, blob in attachments.items():
+            zf.writestr(name, blob)
+
+    logger.info("evidence_bundle_v1_generated path=%s records=%d tenant=%s",
+                path, len(chain_entries), tenant)
+    return os.path.abspath(path), manifest
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/air_blackbox/export/mappings/sb24-205.json
+++ b/sdk/air_blackbox/export/mappings/sb24-205.json
@@ -1,0 +1,37 @@
+{
+  "framework": "CO-SB24-205",
+  "framework_name": "Colorado SB 24-205 (Consumer Protections for Artificial Intelligence)",
+  "scope_note": "This mapping explains which statutory deployer duty each record category evidences. It supports an impact assessment and audit readiness; it is not a legal compliance determination.",
+  "mappings": [
+    {
+      "record_category": "screening_decision",
+      "duty": "Human review protocols and decision logs",
+      "how": "Each consequential decision carries the reviewer identity, review outcome, timestamp, and a tamper-evident signature."
+    },
+    {
+      "record_category": "blocked_action",
+      "duty": "Risk mitigation record",
+      "how": "Covenant-blocked actions are contemporaneous proof that guardrails operated and were enforced."
+    },
+    {
+      "record_category": "human_approval",
+      "duty": "Human oversight of consequential decisions",
+      "how": "Approval records show a named human authorized each gated decision before it took effect, with a signed, timestamped receipt."
+    },
+    {
+      "record_category": "chain_verification",
+      "duty": "Contemporaneous, unaltered records",
+      "how": "HMAC chain plus per-record public-key receipts prove records were not modified after the fact."
+    },
+    {
+      "record_category": "agent_action",
+      "duty": "Documentation of system operation",
+      "how": "Every consequential agent step (profile reads, drafts, LLM calls) is recorded in order with a policy decision attached, documenting how the system actually operated during the covered period."
+    },
+    {
+      "record_category": "outcome_monitoring",
+      "duty": "Ongoing monitoring for algorithmic discrimination",
+      "how": "Deployer-supplied. AIR deliberately records no protected-class attributes; the deployer's own outcome analysis ships under attachments/ and the manifest marks this duty as deployer-supplied."
+    }
+  ]
+}

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -243,16 +243,12 @@ def _sign_receipt(tenant: str, action: str, decision: str, detail: str,
     return receipt.to_dict()
 
 
-@app.tool()
-def record_action(action: str, detail: str = "", model: str = "",
-                  tokens_total: int = 0, category: str = "") -> str:
-    """Record an agent action into the tamper-evident audit chain.
-
-    Call this for every consequential step you take (profile read,
-    outreach draft, decision, message sent). If a covenant is loaded and
-    forbids the action, it is recorded as BLOCKED and you must not
-    proceed with it.
-    """
+def _record_event(action: str, detail: str = "", model: str = "",
+                  tokens_total: int = 0, category: str = "",
+                  extra: dict | None = None) -> str:
+    """Shared core for record_action and log_screening_decision: evaluate
+    the covenant, build the record (plus any structured extra fields), sign
+    the receipt, and chain it."""
     tenant = _current_tenant()
     decision = "permit"
     no_rule = False
@@ -273,6 +269,8 @@ def record_action(action: str, detail: str = "", model: str = "",
         "covenant_decision": decision,
         "tokens": {"total": tokens_total},
     }
+    if extra:
+        record.update(extra)
     if _covenant:
         record["covenant_hash"] = _covenant.hash
     # Attach a signed Gate receipt: the record now carries a non-repudiable
@@ -298,6 +296,20 @@ def record_action(action: str, detail: str = "", model: str = "",
                 f"REQUIRES HUMAN APPROVAL before you proceed. Ask the user "
                 f"to explicitly approve, then record the approval.")
     return f"Recorded, chain_hash={chain_hash}"
+
+
+@app.tool()
+def record_action(action: str, detail: str = "", model: str = "",
+                  tokens_total: int = 0, category: str = "") -> str:
+    """Record an agent action into the tamper-evident audit chain.
+
+    Call this for every consequential step you take (profile read,
+    outreach draft, decision, message sent). If a covenant is loaded and
+    forbids the action, it is recorded as BLOCKED and you must not
+    proceed with it.
+    """
+    return _record_event(action=action, detail=detail, model=model,
+                         tokens_total=tokens_total, category=category)
 
 
 @app.tool()
@@ -398,15 +410,18 @@ def _receipt_from_dict(d: dict) -> ActionReceipt:
 
 @app.tool()
 def export_evidence() -> str:
-    """Package all recorded actions into a signed .air-evidence ZIP."""
+    """Package all recorded actions into a signed .air-evidence bundle
+    (v1 layout: manifest.json, records/, verification/, mapping/,
+    attachments/) aligned to SB 24-205 deployer documentation duties.
+    The bundle supports an impact assessment and is audit-ready; it is
+    not a legal compliance determination."""
     from dataclasses import asdict
 
-    from air_blackbox.export.evidence_bundle import generate_evidence_zip
+    from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
     tenant = _current_tenant()
     runs = _tenant_runs_dir(tenant)
     engine = ReplayEngine(runs_dir=runs)
     total = engine.load()
-    key = os.environ.get("TRUST_SIGNING_KEY", "air-blackbox-default")
 
     # The bundle must never quietly attest a broken or partial chain: verify
     # first and stamp the result INTO the signed payload, so a downstream
@@ -418,21 +433,26 @@ def export_evidence() -> str:
     # token travels inside the signed bundle (verifiable offline by a stranger).
     anchor_note, anchor_manifest = _anchor_current_head(tenant)
 
-    path = generate_evidence_zip(
+    # Deployer-supplied register info and attachments. Missing values are
+    # exported as "deployer-supplied" so gaps are explicit, never hidden.
+    system = {
+        "name": os.environ.get("AIR_SYSTEM_NAME", ""),
+        "high_risk_rationale": os.environ.get("AIR_HIGH_RISK_RATIONALE", ""),
+        "deployer": os.environ.get("AIR_SYSTEM_DEPLOYER", ""),
+    }
+    attachments_dir = os.environ.get(
+        "AIR_ATTACHMENTS_DIR", os.path.join(runs, "attachments"))
+
+    path, manifest = generate_evidence_bundle_v1(
         chain_entries=engine._raw_records,
-        scan_results={"source": "air-blackbox MCP server", "tenant": tenant,
-                      "records": total,
-                      "chain_verification": {
-                          "fully_intact": fully_intact,
-                          **asdict(verification)},
-                      # Publish the receipt public key so a third party can
-                      # verify every action's Ed25519 signature independently.
-                      "receipt_signing_method": _tenant_signer(tenant).method,
-                      "receipt_public_key": _tenant_signer(tenant).public_key_hex or "",
-                      # The external timestamp anchor (or a recorded gap), so the
-                      # bundle proves the head was bound at a past time.
-                      "anchor": anchor_manifest},
-        signing_key=key, output_dir=runs)
+        tenant=tenant,
+        signer=_tenant_signer(tenant),
+        chain_verification={"fully_intact": fully_intact,
+                            **asdict(verification)},
+        system=system,
+        attachments_dir=attachments_dir,
+        anchor_manifest=anchor_manifest,
+        output_dir=runs)
 
     if not verification.intact:
         return (f"WARNING - BROKEN CHAIN EXPORTED: {path}. The chain fails "
@@ -446,9 +466,16 @@ def export_evidence() -> str:
                 f"{verification.verified_records} of {total} records verified; "
                 f"{unchained} carry no chain hash. The manifest records this. "
                 f"Tell the user.")
+    gaps = manifest["counts"]["screening_decisions_missing_reviewer"]
+    gap_note = ""
+    if gaps:
+        gap_note = (f" NOTE: {gaps} screening decision(s) carry no "
+                    f"human_reviewer - flagged in the manifest as review-"
+                    f"protocol gaps; tell the user.")
     return (f"Evidence bundle written: {path} ({total} records, chain fully "
-            f"verified at export time; verification stamped into the manifest). "
-            f"{anchor_note}")
+            f"verified at export time; verification stamped into the signed "
+            f"manifest; verify independently with 'air-evidence verify "
+            f"<bundle>'). {anchor_note}{gap_note}")
 
 
 def _anchor_dir(tenant: str) -> str:
@@ -546,7 +573,11 @@ def verify_anchor() -> str:
 
 @app.tool()
 def log_screening_decision(candidate: str, decision: str,
-                           rationale: str = "") -> str:
+                           rationale: str = "",
+                           decision_type: str = "",
+                           human_reviewer: str = "",
+                           review_action: str = "",
+                           covenant_check_ref: str = "") -> str:
     """REQUIRED whenever you evaluate, rank, advance, reject, or recommend
     an outcome for a candidate - even informally in conversation. Call this
     BEFORE stating the decision to the user.
@@ -555,18 +586,41 @@ def log_screening_decision(candidate: str, decision: str,
     Candidate-affecting decisions are automated decision-making under GDPR
     Art 22 / EU AI Act Art 14: if this returns REQUIRES HUMAN APPROVAL, stop
     and get the user's explicit yes before finalizing anything.
+
+    Human-review-protocol fields (SB 24-205 deployer documentation - fill
+    whenever a human was involved; decisions recorded without a
+    human_reviewer are flagged as gaps in the exported evidence bundle):
+      decision_type      - advance | reject | rank | recommend
+      human_reviewer     - identity of the person who reviewed the output
+      review_action      - approved | overridden | modified
+      covenant_check_ref - chain hash of the check_covenant / record_action
+                           result that gated this decision
     """
     action_map = {
         "advance": "advance_candidate", "reject": "reject_candidate",
         "score": "score_candidate", "rank": "rank_candidates",
         "shortlist": "rank_candidates", "hold": "score_candidate",
     }
-    action = action_map.get(decision.strip().lower(), "score_candidate")
-    return record_action(
+    d = decision.strip().lower()
+    action = action_map.get(d, "score_candidate")
+    if not decision_type:
+        # Derive the SB 24-205 decision_type from the decision verb so every
+        # screening record is categorizable even when the caller omits it.
+        decision_type = {"advance": "advance", "reject": "reject",
+                         "rank": "rank", "shortlist": "rank"}.get(d, "recommend")
+    screening = {"decision_type": decision_type}
+    if human_reviewer:
+        screening["human_reviewer"] = human_reviewer[:100]
+    if review_action:
+        screening["review_action"] = review_action.strip().lower()[:20]
+    if covenant_check_ref:
+        screening["covenant_check_ref"] = covenant_check_ref[:128]
+    return _record_event(
         action=action,
         detail=f"candidate={candidate[:100]}; decision={decision}; "
                f"rationale={rationale[:300]}",
         category="screening",
+        extra={"screening": screening},
     )
 
 

--- a/tests/test_evidence_bundle_v1.py
+++ b/tests/test_evidence_bundle_v1.py
@@ -1,0 +1,246 @@
+"""Evidence Bundle v1: generation, signing, and independent verification.
+
+Covers the five verifier checks plus tamper detection: a bundle must verify
+clean end-to-end, and any post-signing alteration (records, manifest, or a
+receipt) must fail loudly with the offending record identified.
+"""
+
+import hashlib
+import hmac as hmac_mod
+import io
+import json
+import os
+import zipfile
+
+import pytest
+
+from air_blackbox.evidence_verify import (
+    VerificationFailure,
+    main as verify_main,
+    verify_bundle,
+)
+from air_blackbox.export.evidence_bundle import (
+    canonical_manifest_bytes,
+    categorize_record,
+    generate_evidence_bundle_v1,
+)
+from air_blackbox.gate.receipt import ActionReceipt, ReceiptSigner, hash_payload
+
+HMAC_KEY = "test-signing-key"
+
+
+@pytest.fixture()
+def signer():
+    return ReceiptSigner(private_key=os.urandom(32), hmac_key=HMAC_KEY)
+
+
+def _record(signer, action, detail="", status="success",
+            decision="permit", screening=None):
+    receipt = ActionReceipt(
+        agent_id="test-tenant", action_name=action,
+        action_category="screening" if screening is not None else "",
+        payload_hash=hash_payload(detail) if detail else "",
+        covenant_hash="cov-hash", decision=decision,
+        authorized=(decision == "permit"))
+    signer.sign_authorization(receipt)
+    rec = {
+        "run_id": f"run-{action}-{os.urandom(4).hex()}",
+        "timestamp": "2026-07-18T12:00:00+00:00",
+        "type": "agent_action",
+        "action": action,
+        "detail": detail,
+        "model": "",
+        "status": status,
+        "covenant_decision": decision,
+        "tokens": {"total": 0},
+        "receipt": receipt.to_dict(),
+    }
+    if screening is not None:
+        rec["screening"] = screening
+    return rec
+
+
+def _chain(records):
+    """Apply the production HMAC chain over the records in order."""
+    prev = b"genesis"
+    for rec in records:
+        body = {k: v for k, v in rec.items() if k != "chain_hash"}
+        h = hmac_mod.new(HMAC_KEY.encode(),
+                         prev + json.dumps(body, sort_keys=True).encode(),
+                         hashlib.sha256)
+        rec["chain_hash"] = h.hexdigest()
+        prev = h.digest()
+    return records
+
+
+@pytest.fixture()
+def records(signer):
+    return _chain([
+        _record(signer, "read_profile", "candidate profile read"),
+        _record(signer, "reject_candidate",
+                "candidate=Ada; decision=reject", decision="require_approval",
+                screening={"decision_type": "reject",
+                           "human_reviewer": "j.smith",
+                           "review_action": "approved"}),
+        _record(signer, "score_candidate", "candidate=Bo; decision=score",
+                screening={"decision_type": "recommend"}),  # no reviewer: gap
+        _record(signer, "human_approval",
+                "reject_candidate for Ada, approved by user"),
+        _record(signer, "infer_protected_attributes", "age guess attempt",
+                status="blocked", decision="forbid"),
+    ])
+
+
+@pytest.fixture()
+def bundle(tmp_path, records, signer):
+    attach = tmp_path / "attachments"
+    attach.mkdir()
+    (attach / "impact-assessment.md").write_text("# Impact assessment\n")
+    path, manifest = generate_evidence_bundle_v1(
+        chain_entries=records,
+        tenant="test-tenant",
+        signer=signer,
+        chain_verification={"fully_intact": True, "intact": True,
+                            "verified_records": len(records)},
+        system={"name": "Test screening agent", "deployer": "Test LLC",
+                "high_risk_rationale": "employment decisions"},
+        attachments_dir=str(attach),
+        output_dir=str(tmp_path))
+    return path, manifest
+
+
+def test_categorize_record(records):
+    cats = [categorize_record(r) for r in records]
+    assert cats == ["agent_action", "screening_decision",
+                    "screening_decision", "human_approval", "blocked_action"]
+
+
+def test_manifest_shape_and_counts(bundle):
+    _, manifest = bundle
+    assert manifest["bundle_version"] == "1.0"
+    assert manifest["counts"] == {
+        "actions": 5, "screening_decisions": 2, "blocked_actions": 1,
+        "human_approvals": 1, "screening_decisions_missing_reviewer": 1}
+    assert manifest["frameworks"] == ["CO-SB24-205"]
+    assert manifest["outcome_monitoring"] == "deployer-supplied"
+    assert manifest["system"]["deployer"] == "Test LLC"
+    assert manifest["retention_until"] > manifest["created_at"][:10]
+    assert "attachments/impact-assessment.md" in manifest["files"]
+    sig = manifest["signature"]
+    assert sig["alg"] == "ed25519"
+    assert sig["upgrade_path"] == "ML-DSA-65"
+    digest = hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+    assert digest == sig["signed_digest"]
+
+
+def test_clean_bundle_verifies(bundle, capsys):
+    path, _ = bundle
+    summary = verify_bundle(path, hmac_key=HMAC_KEY, out=io.StringIO())
+    assert summary["records"] == 5
+    assert summary["alterations"] == 0
+    assert summary["fingerprint"].startswith("ed25519:")
+    # CLI end-to-end, no secret
+    assert verify_main(["verify", path]) == 0
+    out = capsys.readouterr().out
+    assert "VERIFIED: 5 records, 0 alterations, signed by ed25519:" in out
+
+
+def _rewrite_member(path, member, new_bytes):
+    """Rewrite one member of the ZIP in place (rebuild, preserving others)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(path) as zin, \
+            zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.namelist():
+            zout.writestr(item, new_bytes if item == member
+                          else zin.read(item))
+    with open(path, "wb") as f:
+        f.write(buf.getvalue())
+
+
+def test_tampered_record_fails_file_digest(bundle):
+    path, _ = bundle
+    with zipfile.ZipFile(path) as zf:
+        lines = zf.read("records/actions.jsonl").decode().splitlines()
+    rec = json.loads(lines[2])
+    rec["detail"] = "candidate=Bo; decision=advance"  # attacker edit
+    lines[2] = json.dumps(rec, sort_keys=True)
+    _rewrite_member(path, "records/actions.jsonl", "\n".join(lines) + "\n")
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, out=io.StringIO())
+    assert e.value.check == 2
+    assert "records/actions.jsonl" in e.value.message
+
+
+def test_tampered_manifest_fails_signature(bundle):
+    path, _ = bundle
+    with zipfile.ZipFile(path) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+    manifest["counts"]["blocked_actions"] = 0  # hide the block
+    _rewrite_member(path, "manifest.json", json.dumps(manifest, indent=2))
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, out=io.StringIO())
+    assert e.value.check == 2
+    assert "digest mismatch" in e.value.message
+
+
+def test_resigned_manifest_count_lie_fails_check5(bundle, signer):
+    """Even an attacker WITH the manifest-signing ability can't lie about
+    counts: check 5 recomputes them from the records."""
+    path, _ = bundle
+    with zipfile.ZipFile(path) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+    manifest["counts"]["blocked_actions"] = 0
+    digest = hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+    manifest["signature"]["signed_digest"] = digest
+    manifest["signature"]["value"] = signer.sign(bytes.fromhex(digest))
+    _rewrite_member(path, "manifest.json", json.dumps(manifest, indent=2))
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, out=io.StringIO())
+    assert e.value.check == 5
+    assert "blocked_actions" in e.value.message
+
+
+def test_invalid_receipt_fails_check4(tmp_path, signer, records):
+    records[1]["receipt"]["authorization_sig"] = "00" * 64  # forged
+    path, _ = generate_evidence_bundle_v1(
+        chain_entries=_chain(records), tenant="test-tenant", signer=signer,
+        chain_verification={"fully_intact": True},
+        output_dir=str(tmp_path))
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, out=io.StringIO())
+    assert e.value.check == 4
+    assert records[1]["run_id"] in e.value.message
+
+
+def test_chain_recompute_catches_pre_export_alteration(tmp_path, signer,
+                                                       records):
+    """A record altered after chaining but before export: file digests and
+    receipts still pass (the bundle faithfully packages what it was given),
+    but the --key HMAC recompute exposes the break."""
+    records[0]["detail"] = "altered after chaining"
+    path, _ = generate_evidence_bundle_v1(
+        chain_entries=records, tenant="test-tenant", signer=signer,
+        chain_verification={"fully_intact": False},
+        output_dir=str(tmp_path))
+    # Without the key: structural checks pass, receipt of record 0 still
+    # verifies (payload_hash is inside the receipt, not re-derived).
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, hmac_key=HMAC_KEY, out=io.StringIO())
+    assert e.value.check == 3
+    assert records[0]["run_id"] in e.value.message
+
+
+def test_missing_required_file_fails_check1(bundle):
+    path, _ = bundle
+    buf = io.BytesIO()
+    with zipfile.ZipFile(path) as zin, \
+            zipfile.ZipFile(buf, "w") as zout:
+        for item in zin.namelist():
+            if item != "verification/receipts.json":
+                zout.writestr(item, zin.read(item))
+    with open(path, "wb") as f:
+        f.write(buf.getvalue())
+    with pytest.raises(VerificationFailure) as e:
+        verify_bundle(path, out=io.StringIO())
+    assert e.value.check == 1
+    assert "receipts.json" in e.value.message


### PR DESCRIPTION
Implements the AIR Evidence Bundle v1 spec — the deliverable format for the AI Hiring Audit-Readiness Assessment. Positioning holds throughout: the bundle *supports an impact assessment* and is *audit-ready*; it never claims legal compliance.

## What's in it
- **v1 `.air-evidence` layout**: signed `manifest.json`, `records/actions.jsonl`, `verification/{chain,receipts}.json` + `public_key.pem`, `mapping/sb24-205.json`, deployer `attachments/` passthrough
- **`log_screening_decision`**: 4 optional human-review fields; missing reviewers are flagged as gaps in the manifest (useful assessment output), never hidden. Backward compatible.
- **Canonical manifest signing**: sha256 of sorted-keys/no-whitespace JSON (signature excluded), digest signed via the existing receipt-signer path (Ed25519, `upgrade_path: ML-DSA-65` reserved). `manifest.files` digests every member, so one public-key signature covers the entire bundle — **no secrets needed to verify**.
- **`air-evidence verify`** CLI: 5 ordered checks, loud failure with exact `run_id`, ends `VERIFIED: N records, 0 alterations, signed by <fingerprint>`. `--key` optionally adds the full HMAC chain recompute.
- **Outcome monitoring deliberately excluded** per spec §6 — manifest carries `outcome_monitoring: deployer-supplied`.
- `frameworks` lists only `CO-SB24-205` (the mapping actually shipped); LL144/EU files are the documented follow-on.

## Test plan
- ✅ 9 new tests: clean verify round-trip, tampered record/manifest/receipt, re-signed count lie caught by check 5, `--key` chain recompute break, missing required file
- ✅ Full suite: 51 passed (pre-existing `test_gate.py` setup error exists on main, unrelated)
- ✅ End-to-end smoke through the real MCP module: covenant-gated screening decisions → export (TSA anchor included, 1 reviewer gap flagged in the return message) → `air-evidence verify` passes with and without secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)