### PR TITLE
test: align broken-chain export test with Evidence Bundle v1 format

### DIFF
--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -179,12 +179,14 @@ def test_export_warns_on_broken_chain(tmp_path, monkeypatch):
     assert "WARNING - BROKEN CHAIN EXPORTED" in out
     assert "NOT clean compliance evidence" in out
 
-    # The signed payload itself carries the failure.
-    zpath = glob.glob(os.path.join(tmp_path, "air-evidence-*.zip"))[0]
+    # The signed payload itself carries the failure (v1 bundle: the
+    # verify_chain result is stamped into verification/chain.json).
+    zpath = glob.glob(os.path.join(tmp_path, "bundle-*.air-evidence"))[0]
     with zipfile.ZipFile(zpath) as z:
-        scan = json.loads(z.read("scan_results.json"))
-    assert scan["chain_verification"]["fully_intact"] is False
-    assert scan["chain_verification"]["intact"] is False
+        chain_doc = json.loads(z.read("verification/chain.json"))
+    verification = chain_doc["verification_at_export"]
+    assert verification["fully_intact"] is False
+    assert verification["intact"] is False
 
 
 def test_export_clean_chain_reports_verified(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes the `python-test` failure on main after #46: `test_export_warns_on_broken_chain` still expected the legacy bundle (`air-evidence-*.zip` + `scan_results.json`). v1 bundles are `bundle-*.air-evidence` with the verify_chain result in `verification/chain.json` → `verification_at_export`.

Verified locally with the exact CI invocation (`PYTHONPATH=sdk pytest tests/ sdk/tests/`): the target test passes; the only remaining failures are two `test_static_verifier_*` tests that fail identically on unmodified main in my local env (mcp/pydantic version skew) and pass in CI.

Worth a follow-up: `python-test` is not a required status check, so auto-merge landed #46 before it ran. Making it required would have caught this pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)