### PR TITLE
Scheduled auto-export: evidence without asking

### DIFF
--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -25,6 +25,10 @@ primary_region = "iad"
   # fly.dev hostname so you can test before the custom domain is wired.
   AIR_MCP_ALLOWED_HOSTS = "air-mcp.fly.dev,mcp.airblackbox.ai"
   AIR_COVENANT = "/app/sdk/air_blackbox/gate/examples/recruiting-screener.covenant.yaml"
+  # Evidence must not depend on a busy human asking: every tenant with new
+  # records gets a fresh signed bundle on this interval, written to the
+  # volume (deployer-controlled storage).
+  AIR_AUTO_EXPORT_INTERVAL_HOURS = "24"
   #
   # OAuth (resource-server). Production: point at your IdP's introspection
   # endpoint so claude.ai tokens are verified per request and tenants isolate

--- a/sdk/air_blackbox/export/evidence_bundle.py
+++ b/sdk/air_blackbox/export/evidence_bundle.py
@@ -321,7 +321,10 @@ def generate_evidence_bundle_v1(
         "public_key_hex": signer.public_key_hex or "",
     }
 
-    bundle_name = f"bundle-{now.strftime('%Y-%m-%d-%H%M%S')}-{tenant}.air-evidence"
+    # Timestamp for sortability + bundle-id fragment for uniqueness: two
+    # exports in the same second must never overwrite each other's evidence.
+    bundle_name = (f"bundle-{now.strftime('%Y-%m-%d-%H%M%S')}-{tenant}"
+                   f"-{manifest['bundle_id'][:8]}.air-evidence")
     path = os.path.join(output_dir, bundle_name)
     with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("manifest.json", json.dumps(manifest, indent=2))

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -512,10 +512,16 @@ def export_evidence() -> str:
     attachments/) aligned to SB 24-205 deployer documentation duties.
     The bundle supports an impact assessment and is audit-ready; it is
     not a legal compliance determination."""
+    return _export_tenant(_current_tenant())
+
+
+def _export_tenant(tenant: str) -> str:
+    """Core evidence export for one tenant. Called by the export_evidence
+    tool and by the auto-export scheduler - evidence must never depend on
+    a busy human remembering to ask for it."""
     from dataclasses import asdict
 
     from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
-    tenant = _current_tenant()
     runs = _tenant_runs_dir(tenant)
     engine = ReplayEngine(runs_dir=runs)
     total = engine.load()
@@ -743,6 +749,89 @@ required approval), then call export_evidence and tell me where the signed
 bundle is."""
 
 
+# --- Auto-export: evidence must not depend on a busy human asking --------
+# With AIR_AUTO_EXPORT_INTERVAL_HOURS set, every tenant with new records
+# since its last bundle gets a fresh signed .air-evidence written to its
+# runs directory on the interval. Records and bundles live wherever the
+# deployer mounts AIR_RUNS_DIR (a volume, S3-backed mount, NFS - storage
+# the org controls), so evidence accumulates with zero user action.
+_AUTO_EXPORT_STATE = ".air-auto-export.json"
+
+
+def _tenants_on_disk() -> list:
+    """Every tenant that has chained records: the root dir ("_local") plus
+    one subdirectory per authenticated tenant."""
+    import glob as _glob
+    tenants = []
+    if _glob.glob(os.path.join(RUNS_DIR, "*.air.json")):
+        tenants.append("_local")
+    try:
+        for name in sorted(os.listdir(RUNS_DIR)):
+            sub = os.path.join(RUNS_DIR, name)
+            if os.path.isdir(sub) and _glob.glob(os.path.join(sub, "*.air.json")):
+                tenants.append(name)
+    except OSError:
+        pass
+    return tenants
+
+
+def _auto_export_once() -> int:
+    """Export a fresh bundle for every tenant with records newer than its
+    last export. Returns the number of bundles written. Never raises: one
+    tenant's failure must not starve the others."""
+    import glob as _glob
+    import json as _json
+    exported = 0
+    for tenant in _tenants_on_disk():
+        runs = _tenant_runs_dir(tenant)
+        count = len(_glob.glob(os.path.join(runs, "*.air.json")))
+        state_path = os.path.join(runs, _AUTO_EXPORT_STATE)
+        last = 0
+        try:
+            with open(state_path) as f:
+                last = int(_json.load(f).get("exported_records", 0))
+        except (OSError, ValueError):
+            pass
+        if count <= last:
+            continue
+        try:
+            _export_tenant(tenant)
+            with open(state_path, "w") as f:
+                _json.dump({"exported_records": count,
+                            "exported_at": datetime.now(timezone.utc).isoformat()}, f)
+            exported += 1
+            logger.info("auto_export tenant=%s records=%d", tenant, count)
+        except Exception:
+            logger.exception("auto_export failed tenant=%s", tenant)
+    return exported
+
+
+def _start_auto_export():
+    """Start the daemon scheduler when AIR_AUTO_EXPORT_INTERVAL_HOURS > 0."""
+    try:
+        hours = float(os.environ.get("AIR_AUTO_EXPORT_INTERVAL_HOURS", "0") or 0)
+    except ValueError:
+        logger.warning("invalid AIR_AUTO_EXPORT_INTERVAL_HOURS; auto-export off")
+        return None
+    if hours <= 0:
+        return None
+    import threading
+    import time as _time
+
+    def _loop():
+        while True:
+            _time.sleep(hours * 3600)
+            try:
+                _auto_export_once()
+            except Exception:
+                logger.exception("auto_export sweep failed")
+
+    t = threading.Thread(target=_loop, daemon=True, name="air-auto-export")
+    t.start()
+    logger.info("auto_export enabled: every %.2fh", hours)
+    return t
+
+
 def main():
     """Run over stdio (Claude Desktop) or HTTP (claude.ai custom connector).
 
@@ -751,6 +840,7 @@ def main():
     https://mcp.airblackbox.ai/mcp and add it in claude.ai as a custom
     connector. Default is stdio for local Claude Desktop use.
     """
+    _start_auto_export()
     if os.environ.get("AIR_MCP_TRANSPORT", "stdio") == "http":
         app.settings.host = os.environ.get("AIR_MCP_HOST", "0.0.0.0")
         app.settings.port = int(os.environ.get("AIR_MCP_PORT", "8085"))

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -270,3 +270,37 @@ def test_tampered_receipt_is_caught(tmp_path, monkeypatch):
 
     out = srv.verify_receipts()
     assert "RECEIPT FAILURE" in out
+
+
+def test_auto_export_writes_bundle_only_on_new_records(tmp_path, monkeypatch):
+    """Auto-export bundles every tenant with new records, exactly once per
+    high-water mark - evidence accumulates with zero user action."""
+    import glob
+    import air_blackbox.mcp_server as srv
+    monkeypatch.setattr(srv, "_covenant", None)
+    monkeypatch.setattr(srv, "RUNS_DIR", str(tmp_path))
+    srv._chains.clear()
+
+    srv.record_action("read_profile")
+    srv.record_action("draft_message")
+
+    assert srv._auto_export_once() == 1
+    bundles = glob.glob(os.path.join(tmp_path, "bundle-*.air-evidence"))
+    assert len(bundles) == 1
+
+    # No new records: sweep is a no-op.
+    assert srv._auto_export_once() == 0
+    assert len(glob.glob(os.path.join(tmp_path, "bundle-*.air-evidence"))) == 1
+
+    # A new record triggers exactly one fresh bundle.
+    srv.record_action("read_profile")
+    assert srv._auto_export_once() == 1
+    assert len(glob.glob(os.path.join(tmp_path, "bundle-*.air-evidence"))) == 2
+
+
+def test_auto_export_disabled_without_env(monkeypatch):
+    import air_blackbox.mcp_server as srv
+    monkeypatch.delenv("AIR_AUTO_EXPORT_INTERVAL_HOURS", raising=False)
+    assert srv._start_auto_export() is None
+    monkeypatch.setenv("AIR_AUTO_EXPORT_INTERVAL_HOURS", "not-a-number")
+    assert srv._start_auto_export() is None


### PR DESCRIPTION
Recruiters are spread thin and will never remember to export evidence — so evidence can't depend on anyone asking.

- `AIR_AUTO_EXPORT_INTERVAL_HOURS` (off by default): daemon sweep exports a fresh signed v1 bundle for every tenant whose chain grew since its last bundle, into the tenant's runs directory — i.e. whatever storage the deployer mounts (fly volume, S3-backed mount, NFS). Zero user action; org-controlled storage.
- Per-tenant high-water mark in `.air-auto-export.json`; one tenant's failure never starves the others; `export_evidence` tool refactored onto the same `_export_tenant` core.
- **Bug fix found by the new test:** bundle filenames had 1-second resolution — two exports in the same second silently overwrote each other. Names now include the bundle id.
- Demo deployment (fly.toml) set to 24h.

## Test plan
- ✅ New tests: bundle written once per high-water mark, no-op sweep, second bundle on new records, disabled without env / invalid env
- ✅ Full suite: 158 passed locally (the two `test_static_verifier_*` failures are the known local-env pydantic skew; pass in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)