### PR TITLE
ci: install python-test deps from pyproject (kill dependency drift)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install test dependencies
-        run: pip install pytest cryptography pyarrow pyyaml httpx mcp pyjwt rich click
+        # Install the package itself so runtime deps come from pyproject and
+        # can't drift from what the code imports; extras cover the optional
+        # features the suite exercises (mcp -> mcp+pyjwt, lake -> pyarrow).
+        run: pip install -e ".[mcp,lake]" pytest
       - name: Test SDK
         run: PYTHONPATH=sdk python -m pytest tests/ sdk/tests/ -q
 


### PR DESCRIPTION
## What does this PR do?
Root-cause fix for the dependency drift that broke `main` twice this week (the `rich` miss in #52, and the shape of the #46 break before it).

The `python-test` job installed a **hand-maintained subset** of packages:
```
pip install pytest cryptography pyarrow pyyaml httpx mcp pyjwt rich click
```
That list inevitably falls behind what the code imports — `pyproject.toml` already declares `rich`/`click` as core deps, but the list omitted them, so the first test to import the CLI broke collection.

**Fix:** install the package with its extras so runtime deps come from pyproject, not a duplicate list:
```
pip install -e ".[mcp,lake]" pytest
```
Core deps (click, rich, httpx, pydantic, pyyaml, cryptography) now come from `[project.dependencies]`; `mcp` brings `mcp`+`pyjwt`, `lake` brings `pyarrow` — exactly the optional features the suite exercises. Adding a new import of an already-declared dependency can never silently break CI again.

## Type of change
- [x] Refactor / code quality (CI hardening)

## EU AI Act articles affected
N/A (CI only).

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass — clean venv installing exactly `pip install -e ".[mcp,lake]" pytest` runs the full CI invocation: **293 passed**
- [x] I have added/updated docstrings where needed (N/A)
- [x] My changes do not break backward compatibility

## Additional notes
Complements the still-recommended repo-settings change only you can make: mark **`python-test` a required status check** (Settings → Branches → `main`) so a red build can't merge — that's the guardrail that would have stopped both recent breaks pre-merge. Recommend **squash merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_