### PR TITLE
Security review fixes: tenant injectivity (#56) + JWT/static-token hardening (#59) + unblock CI (mcp<2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**Security**
+- MCP tenant isolation: the authenticated-subject → tenant-directory mapping is now injective (readable prefix + SHA-256 of the full subject). The previous fold-and-truncate mapping could collide two different subjects onto one tenant (e.g. `alice@corp.com` ≡ `alice_corp_com`, or any two subjects sharing a 64-char prefix), and could route an authenticated subject into the shared `_local` root or the `public-demo` chain. Fixes #56.
+
 **Added**
 - Add static dependency discovery for AI-BOM output from requirements.txt, pyproject.toml, package.json, and package-lock.json.
 - Add configurable AI-library dependency classification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Security**
 - MCP tenant isolation: the authenticated-subject → tenant-directory mapping is now injective (readable prefix + SHA-256 of the full subject). The previous fold-and-truncate mapping could collide two different subjects onto one tenant (e.g. `alice@corp.com` ≡ `alice_corp_com`, or any two subjects sharing a 64-char prefix), and could route an authenticated subject into the shared `_local` root or the `public-demo` chain. Fixes #56.
+- MCP JWT auth now **refuses to start** in JWKS mode unless `AIR_MCP_JWT_AUDIENCE` is set (or `AIR_MCP_JWT_ALLOW_ANY_AUDIENCE=1` is explicitly set). Previously, a JWKS-only config accepted any validly-signed token from the IdP, including one minted for a different API behind the same tenant (confused-deputy replay). Static tokens without an explicit subject now derive it from a hash of the full token instead of a 12-char prefix (prefix-sharing tokens no longer collapse onto one tenant), and malformed empty-token entries are skipped. Part of #59.
 
 **Added**
 - Add static dependency discovery for AI-BOM output from requirements.txt, pyproject.toml, package.json, and package-lock.json.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ claude = ["claude-agent-sdk>=0.1.0"]
 pdf = ["reportlab>=4.0"]
 gate = ["cryptography>=42.0"]
 lake = ["pyarrow>=14.0"]  # Parquet lake sink + in-lake chain verification
-mcp = ["mcp>=1.0", "pyjwt>=2.8"]  # governance MCP server for Claude (record/enforce/prove)
+mcp = ["mcp>=1.0,<2", "pyjwt>=2.8"]  # governance MCP server for Claude (record/enforce/prove); <2: mcp 2.0 removed mcp.server.fastmcp (see #59 follow-up)
 pqc = ["oqs>=0.10.0"]  # post-quantum ML-DSA-65 signing (opt-in)
 all = [
     "air-blackbox[langchain]",

--- a/sdk/air_blackbox/mcp_auth.py
+++ b/sdk/air_blackbox/mcp_auth.py
@@ -30,6 +30,8 @@ The verified subject is what isolates tenants: each subject records into its
 own chain, so one recruiter's evidence never mixes with another's.
 """
 
+import hashlib
+import logging
 import os
 import time
 from typing import Optional
@@ -38,6 +40,8 @@ import httpx
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
 from pydantic import AnyHttpUrl
+
+logger = logging.getLogger("air_blackbox.mcp_auth")
 
 
 class StaticTokenVerifier(TokenVerifier):
@@ -51,7 +55,19 @@ class StaticTokenVerifier(TokenVerifier):
                 continue
             parts = entry.split(":")
             token = parts[0]
-            subject = parts[1] if len(parts) > 1 and parts[1] else token[:12]
+            if not token:
+                # A malformed entry like ":sub" or "::" would otherwise
+                # register an empty-string token that authenticates.
+                continue
+            # When no explicit subject is given, derive it from a hash of the
+            # FULL token, never a prefix: two tokens sharing a brand/product
+            # prefix (a common generation pattern) must not collapse onto the
+            # same tenant.
+            if len(parts) > 1 and parts[1]:
+                subject = parts[1]
+            else:
+                subject = "tok-" + hashlib.sha256(
+                    token.encode("utf-8")).hexdigest()[:16]
             scopes = parts[2].split("|") if len(parts) > 2 and parts[2] else []
             self._tokens[token] = (subject, scopes)
 
@@ -176,10 +192,34 @@ def build_auth():
         return None, None
 
     if jwks:
-        verifier = JwtTokenVerifier(
-            jwks,
-            issuer=os.environ.get("AIR_MCP_JWT_ISSUER") or None,
-            audience=os.environ.get("AIR_MCP_JWT_AUDIENCE") or None)
+        audience = os.environ.get("AIR_MCP_JWT_AUDIENCE") or None
+        issuer = os.environ.get("AIR_MCP_JWT_ISSUER") or None
+        allow_any_aud = os.environ.get(
+            "AIR_MCP_JWT_ALLOW_ANY_AUDIENCE", "").lower() in ("1", "true", "yes")
+        if audience is None and not allow_any_aud:
+            # Without an audience, any validly-signed token from the IdP is
+            # accepted - including a token minted for a DIFFERENT API behind
+            # the same IdP tenant (confused-deputy replay). Refuse to run
+            # rather than default to that hole: the operator must either pin
+            # the audience or explicitly opt into accepting any.
+            raise RuntimeError(
+                "AIR_MCP_JWKS_URL is set but AIR_MCP_JWT_AUDIENCE is not. "
+                "Without an audience, a token issued for another API behind "
+                "the same IdP is replayable against this server. Set "
+                "AIR_MCP_JWT_AUDIENCE to this server's resource identifier "
+                "(e.g. https://mcp.airblackbox.ai), or set "
+                "AIR_MCP_JWT_ALLOW_ANY_AUDIENCE=1 to explicitly accept any "
+                "audience (not recommended).")
+        if audience is None:
+            logger.warning(
+                "AIR_MCP_JWT_ALLOW_ANY_AUDIENCE is set: accepting tokens for "
+                "ANY audience from the IdP. A token minted for another API "
+                "behind the same IdP is replayable against this server.")
+        if issuer is None:
+            logger.warning(
+                "AIR_MCP_JWT_ISSUER is not set: the token issuer is not "
+                "pinned. Set it to your IdP's issuer URL.")
+        verifier = JwtTokenVerifier(jwks, issuer=issuer, audience=audience)
     elif introspection:
         verifier = IntrospectionTokenVerifier(
             introspection, os.environ.get("AIR_MCP_INTROSPECTION_AUTH") or None)

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -20,6 +20,7 @@ Claude Desktop config:
     "args": ["-m", "air_blackbox.mcp_server"]}}}
 """
 
+import hashlib
 import logging
 import os
 import uuid
@@ -245,8 +246,24 @@ _chains: dict = {}
 
 
 def _safe_tenant(subject: str) -> str:
-    # Keep tenant ids filesystem-safe; never let a subject escape RUNS_DIR.
-    return "".join(c if c.isalnum() or c in "-_" else "_" for c in subject)[:64]
+    """Map an authenticated subject to a filesystem-safe, INJECTIVE tenant id.
+
+    The mapping must be injective: two different subjects must never share a
+    tenant, or one tenant could read/write another's audit records. Folding
+    non-alphanumerics to '_' and truncating (the previous approach) is NOT
+    injective - 'alice@corp.com' and 'alice_corp_com' collide, and any two
+    subjects agreeing on their first N chars collide under truncation.
+
+    We take a readable-but-lossy prefix only for debuggability and append a
+    hash of the FULL subject; uniqueness comes entirely from the hash. The
+    hash suffix also guarantees the result can never equal a reserved tenant
+    name (_local, the demo tenant), so no authenticated subject can land in
+    the shared/unauthenticated stores.
+    """
+    digest = hashlib.sha256(subject.encode("utf-8")).hexdigest()[:16]
+    readable = "".join(c if c.isalnum() or c in "-" else "_" for c in subject)
+    readable = readable.strip("_")[:32].strip("_") or "t"
+    return f"{readable}-{digest}"
 
 
 def _current_tenant() -> str:

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -68,11 +68,50 @@ def test_build_auth_introspection_mode(monkeypatch):
 def test_build_auth_jwks_mode_takes_precedence(monkeypatch):
     pytest.importorskip("jwt")
     monkeypatch.setenv("AIR_MCP_JWKS_URL", "https://idp.example.com/.well-known/jwks.json")
+    monkeypatch.setenv("AIR_MCP_JWT_AUDIENCE", "https://mcp.airblackbox.ai")
     monkeypatch.setenv("AIR_MCP_INTROSPECTION_URL", "https://idp.example.com/introspect")
     monkeypatch.setenv("AIR_MCP_TOKENS", "k:tenant1")
     verifier, settings = build_auth()
     assert isinstance(verifier, JwtTokenVerifier)
     assert settings is not None
+
+
+def test_build_auth_jwks_without_audience_refuses_to_start(monkeypatch):
+    # Fail-safe: JWKS mode without a pinned audience must not silently accept
+    # tokens for any audience (confused-deputy replay).
+    pytest.importorskip("jwt")
+    monkeypatch.setenv("AIR_MCP_JWKS_URL", "https://idp.example.com/jwks.json")
+    monkeypatch.delenv("AIR_MCP_JWT_AUDIENCE", raising=False)
+    monkeypatch.delenv("AIR_MCP_JWT_ALLOW_ANY_AUDIENCE", raising=False)
+    with pytest.raises(RuntimeError, match="AIR_MCP_JWT_AUDIENCE"):
+        build_auth()
+
+
+def test_build_auth_jwks_allow_any_audience_is_explicit_optout(monkeypatch):
+    pytest.importorskip("jwt")
+    monkeypatch.setenv("AIR_MCP_JWKS_URL", "https://idp.example.com/jwks.json")
+    monkeypatch.delenv("AIR_MCP_JWT_AUDIENCE", raising=False)
+    monkeypatch.setenv("AIR_MCP_JWT_ALLOW_ANY_AUDIENCE", "1")
+    verifier, settings = build_auth()
+    assert isinstance(verifier, JwtTokenVerifier)
+
+
+def test_static_verifier_no_subject_uses_full_token_hash_not_prefix():
+    # Two tokens sharing a long prefix must NOT collapse onto one subject.
+    v = StaticTokenVerifier("aircompliance-tenantA-secret,aircompliance-tenantB-secret")
+    import asyncio
+    a = asyncio.run(_verify(v, "aircompliance-tenantA-secret"))
+    b = asyncio.run(_verify(v, "aircompliance-tenantB-secret"))
+    assert a is not None and b is not None
+    assert a.subject != b.subject
+
+
+def test_static_verifier_skips_empty_token_entries():
+    # ":sub" / "::" must not register an empty-string token that authenticates.
+    import asyncio
+    v = StaticTokenVerifier(":orphan,::,realtok:alice")
+    assert asyncio.run(_verify(v, "")) is None
+    assert asyncio.run(_verify(v, "realtok")).subject == "alice"
 
 
 # --- JWT / JWKS verification (the mode real IdPs use) ---

--- a/sdk/tests/test_mcp_auth.py
+++ b/sdk/tests/test_mcp_auth.py
@@ -196,9 +196,40 @@ def test_current_tenant_hard_fails_without_subject_when_auth_enabled(monkeypatch
 
 def test_tenant_id_is_filesystem_safe():
     import air_blackbox.mcp_server as srv
-    assert srv._safe_tenant("../etc/passwd") == "___etc_passwd"
-    assert "/" not in srv._safe_tenant("a/b/c")
-    assert srv._safe_tenant("normal-id_1") == "normal-id_1"
+    # No path separators can survive into a tenant id (no RUNS_DIR escape).
+    for subject in ("../etc/passwd", "a/b/c", "..\\..\\x", "a/../../b"):
+        t = srv._safe_tenant(subject)
+        assert "/" not in t and "\\" not in t
+        assert ".." not in t
+
+
+def test_tenant_id_mapping_is_injective():
+    # The core isolation guarantee: distinct subjects -> distinct tenants.
+    # The previous fold-and-truncate mapping collided on all of these.
+    import air_blackbox.mcp_server as srv
+    collision_pairs = [
+        ("alice@corp.com", "alice_corp_com"),            # char folding
+        ("u" + "x" * 63 + "AAA", "u" + "x" * 63 + "BBB"),  # >64-char truncation
+        ("tenant/x", "tenant_x"),
+        ("a.b", "a_b"),
+    ]
+    for a, b in collision_pairs:
+        assert srv._safe_tenant(a) != srv._safe_tenant(b), f"{a!r} collides with {b!r}"
+    # Deterministic: same subject always maps to the same tenant.
+    assert srv._safe_tenant("alice@corp.com") == srv._safe_tenant("alice@corp.com")
+
+
+def test_authenticated_subject_cannot_reach_reserved_tenants():
+    # No authenticated subject may map to the shared unauthenticated root
+    # ("_local") or the public demo tenant, or it would read/write their chains.
+    import air_blackbox.mcp_server as srv
+    for subject in ("_local", ".local", "/local", "@local", "public-demo",
+                    "public/demo", "public.demo"):
+        t = srv._safe_tenant(subject)
+        assert t != "_local"
+        assert t != srv._DEMO_TENANT
+        # And it never resolves to the RUNS_DIR root that "_local" owns.
+        assert srv._tenant_runs_dir(t) != srv.RUNS_DIR
 
 
 def test_tenant_chains_are_isolated(tmp_path, monkeypatch):


### PR DESCRIPTION
Three commits from the #59 security review, bundled because the CI-unblock is a prerequisite for the other two to go green.

### 1. Tenant isolation is injective — fixes #56 (Critical)
`_safe_tenant()` mapped subjects by folding non-alphanumerics to `_` and truncating to 64 chars — not injective, so two different subjects could share one tenant's audit chain (`alice@corp.com` ≡ `alice_corp_com`; any two subjects sharing a 64-char prefix; subjects normalizing to `_local`/`public-demo` landing in the shared/demo stores). Now maps to `<readable-prefix>-<sha256(full-subject)[:16]>`: uniqueness from the full-subject hash, reserved names unreachable, no path escape. Tests assert the invariants (injectivity on the exact collision pairs, no escape, reserved-name unreachability).

### 2. JWT audience + static-token hardening — part of #59 (High/Medium)
- **JWT audience fail-safe:** JWKS mode now **refuses to start** without `AIR_MCP_JWT_AUDIENCE` (or an explicit `AIR_MCP_JWT_ALLOW_ANY_AUDIENCE=1` opt-out). Previously a JWKS-only config accepted any validly-signed token from the IdP — a token minted for another API behind the same tenant was replayable (confused-deputy). Warns when issuer is unpinned.
- **Static-token subjects** derive from `sha256(full-token)` instead of a 12-char prefix (prefix-sharing tokens no longer collapse onto one tenant); malformed empty-token entries are skipped.

### 3. Unblock CI: pin `mcp<2`
`mcp 2.0.0` shipped and removed `mcp.server.fastmcp`, which `mcp_server.py` imports — the unpinned `mcp>=1.0` pulled it on CI and broke 21 MCP tests on every PR. Pinned to the 1.x line (1.29.0 has fastmcp). mcp 2.0 migration is a tracked follow-up.

### Verification
Fresh venv mirroring CI's exact install (`pip install -e ".[mcp,lake]" pytest`, mcp 1.29.0): **299 passed**. All original tenant-collision and token-replay attack vectors verified closed.

### ⚠️ Deploy note
After this merges, a server with `AIR_MCP_JWKS_URL` set but no `AIR_MCP_JWT_AUDIENCE` **will refuse to boot** until the audience is set (or the allow-any escape hatch). This is the intended fail-safe and affects `air-mcp.fly.dev` — set `AIR_MCP_JWT_AUDIENCE` before redeploying.

## Type of change
- [x] Bug fix (security) + CI fix

## Checklist
- [x] Tested locally (299)
- [x] Backward compat: tenant dir names change (no completed-auth tenants exist yet); JWKS deployments must set an audience (intended).

Recommend **squash merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)