### PR TITLE
docs(security): cryptographic posture doc + fix README quantum overclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Every LLM call now generates a signed, tamper-evident, replayable audit record. 
 
 **External anchoring (rewrite detection)**: on every evidence export, the chain head is countersigned by an RFC 3161 timestamp authority — a key the operator does *not* hold. A history that is rewritten and perfectly re-signed still fails `verify_anchor` with a message-imprint mismatch. Tamper-evident against outsiders, rewrite-detectable against the operator. See [ADR 0001](docs/decisions/0001-anchor-rail.md).
 
-**Quantum-safe signing**: the chain is signed with ML-DSA-65 (FIPS 204 / Dilithium3). Keys are generated locally and never leave your machine. Post-quantum secure today.
+**Signed, post-quantum-ready**: the audit chain is HMAC-SHA256 (alter one record and every record after it breaks); each Gate action carries an Ed25519 signature today, with a post-quantum ML-DSA-65 (FIPS 204 / Dilithium3) upgrade path. Keys are generated locally and never leave your machine. What is quantum-exposed, what is not, and the migration plan are written down in the [cryptographic posture](docs/security/cryptographic-posture.md).
 
 **Evidence bundle**: one command packages the records, chain/receipt verification results, the public key, and regulator mappings (Colorado SB 24-205) into a signed `.air-evidence` bundle (v1 format). `air-evidence verify` runs five ordered checks and needs **no secrets** — one public-key signature covers every file in the bundle. Bundles can also auto-export on a schedule (`AIR_AUTO_EXPORT_INTERVAL_HOURS`), so evidence never depends on a busy human remembering to ask for it.
 
@@ -270,7 +270,7 @@ AIR Gateway          <- swap base_url here
     |
     |-- PII + injection scan      (before prompt reaches model)
     |-- HMAC audit record         (async, zero latency impact)
-    |-- ML-DSA-65 signing         (keys never leave your machine)
+    |-- Ed25519 / ML-DSA-65 sign  (keys never leave your machine)
     |
     v
 LLM Provider         <- OpenAI / Anthropic / Azure / local
@@ -288,7 +288,7 @@ Works with any OpenAI-compatible API. Same format, same integration, regardless 
 
 You probably already have logging. The problems logging doesn't solve:
 
-**Tamper-evidence**: anyone with write access to your log store can alter a record. HMAC chains make alteration detectable. ML-DSA-65 signatures prove who signed and when.
+**Tamper-evidence**: anyone with write access to your log store can alter a record. HMAC chains make alteration detectable. Ed25519 signatures (with an ML-DSA-65 post-quantum path) prove who authorized each action.
 
 **Operator rewrite**: a hash chain alone has a blind spot — whoever holds the signing key could rewrite the *entire* history and re-sign it, and every self-check would still pass. AIR closes this by anchoring the chain head to an external timestamp authority on export: a countersignature from a key you don't control. A rewritten history no longer matches what the outside witness saw. You can still lie — but not invisibly. (Most "audit log" tools, including other HMAC hash-chain products, stop before this step.)
 

--- a/docs/security/cryptographic-posture.md
+++ b/docs/security/cryptographic-posture.md
@@ -1,0 +1,102 @@
+# AIR Blackbox: Cryptographic Agility and Post-Quantum Posture
+
+Status: living document. Last updated 2026-08-01.
+
+AIR Blackbox is a trust product: its guarantees rest entirely on cryptography.
+This document states, honestly, which primitives we use, what each one is
+exposed to (including AI-assisted cryptanalysis and quantum computers), how the
+system is designed to replace a primitive without a rewrite, and what is not yet
+production-ready. It is both engineering reference and the answer we give a
+buyer who forwards us a scary crypto headline.
+
+The short version: no primitive is assumed unbreakable. The design assumption is
+that any one of them may need to be replaced, so the architecture is
+crypto-agile (the algorithm is data, not a hard-coded assumption) and relies on
+more than one independent root of trust.
+
+## Primitives in use
+
+| Primitive | Where | Purpose |
+|---|---|---|
+| HMAC-SHA256 | audit chain (`trust/chain.py`) | Tamper-evident links between records. Symmetric; key from `TRUST_SIGNING_KEY` or a per-tenant key file. |
+| SHA-256 | chain head (`anchor/head.py`), payload hashes, manifest digest | Key-free commitments over ordered records and over bundle contents. |
+| Ed25519 | Gate receipts (default), evidence-bundle manifest signature | Non-repudiable signatures verifiable with the public key alone. |
+| ML-DSA-65 (Dilithium3, FIPS 204) | Gate receipts (preferred **when available**) | Post-quantum signature. See "Not yet production-ready" below. |
+| HMAC-SHA256 (fallback) | receipts, when no asymmetric library is present | Last-resort signing. Requires a shared secret; not third-party verifiable. |
+| RFC 3161 timestamp (external) | anchor (`anchor/tsa.py`) | A timestamp authority countersigns the chain head with the authority's own key. Key we do not hold. |
+
+## Threat exposure
+
+### AI-assisted cryptanalysis
+The recent "AI broke AES" style results target **reduced-round variants** of
+ciphers, an established academic activity that does not threaten the full-round
+primitives in production. Full AES-256, SHA-256, and HMAC-SHA256 are not
+affected by that class of result. We track the field, but it does not change our
+current posture.
+
+### Quantum computers
+This is the real long-horizon exposure, and it is uneven across our primitives:
+
+| Primitive | Quantum exposure | Consequence |
+|---|---|---|
+| HMAC-SHA256 / SHA-256 | Grover gives only a quadratic speedup | 256-bit width leaves ~128-bit effective security. Robust; no action needed. |
+| Ed25519 | Shor's algorithm breaks elliptic-curve signatures on a large quantum computer | **This is the primitive to migrate.** Mitigation: the ML-DSA-65 path. |
+| RFC 3161 TSA signature | Depends on the authority's key (often RSA/ECDSA) | Quantum-exposed, but it is the authority's key to migrate, and the anchor is a secondary time-binding root, not the sole guarantee. |
+
+## Why a single break is not a collapse
+
+AIR does not rest on one primitive or one key. It has independent roots of trust:
+
+1. **Chain integrity** is symmetric (HMAC-SHA256), quantum-robust.
+2. **Receipts** are asymmetric (Ed25519, migrating to ML-DSA-65).
+3. **The external anchor** is a timestamp authority's signature over the head, a
+   key the operator does not hold.
+4. **A public transparency log** (roadmap M2) will add a fourth root that no
+   single party controls.
+
+If Ed25519 fell tomorrow, the HMAC chain and the external anchor would still
+detect tampering. That layering is the actual defense.
+
+## Crypto-agility: the algorithm is data
+
+- Every receipt carries a `signing_method` field (`ed25519`, `ML-DSA-65`, or
+  `hmac-sha256`) and its public key, so a verifier adapts to whatever signed it.
+- The chain's construction is recorded in each evidence bundle
+  (`verification/chain.json`), so the hashing scheme is documented, not implied.
+- Because the method travels with the data, migrating a signature algorithm does
+  not require rewriting historical records or the verifier.
+
+## Not yet production-ready (stated plainly)
+
+- **ML-DSA-65 is available but not the default, and not yet production-hardened.**
+  Two blockers, both tracked in issue #63: (a) the signer regenerates its keypair
+  on every construction and ignores a provided key, so per-tenant keys would not
+  survive a restart; (b) the native `liboqs` library is not in CI, so the path
+  has no automated coverage. **The default signature today is Ed25519.** We will
+  not flip the default until persistence is fixed and the path is under test.
+- **The HMAC fallback uses a well-known default key** (`air-blackbox-default`)
+  when no signing key is configured. Any real deployment must set
+  `TRUST_SIGNING_KEY`. This fallback is not third-party verifiable and should be
+  treated as development-only.
+- **Public transparency-log anchoring (M2) is roadmap, not shipped.** External
+  RFC 3161 anchoring (M1) is shipped and is now enforced by the evidence verifier
+  (`air-evidence verify`), which fails on a rewritten history whose anchor does
+  not match. Its documented limitation: an attacker who rewrites history *and*
+  obtains a fresh timestamp for the new head produces a self-consistent bundle.
+  Closing that gap is exactly what the public append-only log (M2) is for.
+
+## Migration plan
+
+1. Fix ML-DSA-65 key persistence (#63) and add `liboqs` to CI, then make
+   ML-DSA-65 the default signature for hosted and high-assurance deployments.
+2. Ship M2 public transparency-log anchoring, removing sole dependence on
+   operator-held keys.
+3. Keep this document current as the cryptographic bill of materials for AIR
+   itself. If a primitive's exposure changes, it is recorded here first.
+
+## What we do not claim
+
+We do not claim any primitive is unbreakable, that AIR is quantum-proof today,
+or that using it makes an organization compliant. We claim that AIR is built to
+replace its cryptography, that it does not depend on any single algorithm or key,
+and that its current gaps are written down rather than hidden.


### PR DESCRIPTION
Adds `docs/security/cryptographic-posture.md` and corrects a README overclaim it exposed.

## Why
AIR is a trust product; its guarantees rest on cryptography. This is the honest cryptographic bill of materials for AIR itself — dual-purpose as engineering reference and as the artifact to hand a buyer who forwards a "AI broke AES / quantum breaks everything" post.

## The posture doc covers
- **Primitives in use** (grounded in code): HMAC-SHA256 chain, SHA-256 heads/digests, Ed25519 receipts (default), ML-DSA-65 (preferred when available), RFC 3161 external anchor.
- **Threat exposure**, honestly split: AI reduced-round results don't touch full-round primitives; quantum's real target is Ed25519 (Shor), which is exactly why the ML-DSA-65 path exists; hashes are quantum-robust at 256-bit.
- **Multi-root trust** so one break isn't a collapse (symmetric chain + asymmetric receipts + external anchor + roadmap public log).
- **Crypto-agility**: `signing_method` travels with the data, so an algorithm can be migrated without rewriting records or the verifier.
- **What is NOT production-ready, stated plainly**: ML-DSA-65 default blocked on #63 (key persistence) + no CI liboqs; HMAC fallback default key; M2 public anchoring on roadmap (M1 external anchoring shipped and enforced by the verifier per #61).

## README fix (real correctness issue)
The "Quantum-safe signing" bullet claimed *the chain is signed with ML-DSA-65* and is *"post-quantum secure today."* Both are inaccurate: the chain is HMAC-SHA256, receipts default to Ed25519, and ML-DSA-65 is not the default (#63). Reworded to "Ed25519 today + ML-DSA-65 upgrade path," linked the posture doc, and softened two related lines. Better to be accurate than to get caught overclaiming in a compliance sale.

## Type of change
- [x] Documentation update (+ a public-facing accuracy fix)

## Checklist
- [x] Every claim grounded in the actual code (no AES/vault cipher claimed, since none is implemented)
- [x] Existing tests unaffected (docs only)

Recommend **squash merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_