### PR TITLE
Close file handles in the proof harness (bot review on #65)

### DIFF
--- a/bench/proof/prove.py
+++ b/bench/proof/prove.py
@@ -145,6 +145,16 @@ def build_genuine(root, tsa):
 # --------------------------------------------------------------------------
 # Scenarios. Each returns {system: outcome}.
 # --------------------------------------------------------------------------
+def _tamper_record(runs, index, field, value):
+    """Falsify one field of the index-th stored record, in place."""
+    p = os.path.join(runs, sorted(os.listdir(runs))[index])
+    with open(p) as f:
+        rec = json.load(f)
+    rec[field] = value
+    with open(p, "w") as f:
+        json.dump(rec, f)
+
+
 def scenario_edit(root, tsa, tsr):
     """Edit a past record's content in place."""
     out = {}
@@ -155,20 +165,12 @@ def scenario_edit(root, tsa, tsr):
 
     # hash chain: mutate a record on disk, re-verify with the key.
     runs, _ = build_genuine(os.path.join(root, "hc_edit"), None)
-    f = sorted(os.listdir(runs))[1]
-    p = os.path.join(runs, f)
-    rec = json.load(open(p))
-    rec["candidate"] = "TAMPERED"
-    json.dump(rec, open(p, "w"))
+    _tamper_record(runs, 1, "candidate", "TAMPERED")
     out["hash chain"] = DETECTED if not hash_chain_intact(runs) else MISSED
 
     # AIR: same tamper; verify_chain catches it (the anchor would too).
     runs2, _ = build_genuine(os.path.join(root, "air_edit"), None)
-    f2 = sorted(os.listdir(runs2))[1]
-    p2 = os.path.join(runs2, f2)
-    rec2 = json.load(open(p2))
-    rec2["candidate"] = "TAMPERED"
-    json.dump(rec2, open(p2, "w"))
+    _tamper_record(runs2, 1, "candidate", "TAMPERED")
     out["AIR Blackbox"] = DETECTED if not hash_chain_intact(runs2) else MISSED
     return out
 


### PR DESCRIPTION
## What

github-code-quality flagged four spots in `bench/proof/prove.py` (`scenario_edit`) where files were opened without being closed: `json.load(open(p))` and `json.dump(rec, open(p, "w"))`.

Real but mild: on CPython the refcounting GC closes these promptly, so the read cases were harmless. The **write** cases were the ones worth fixing — on other runtimes an unclosed write handle can leave an unflushed buffer, and this file is a public credibility artifact that invites people to read it closely.

## Fix

The four calls were the same read-tamper-write sequence duplicated twice, so it's now one `_tamper_record(runs, index, field, value)` helper with proper `with` blocks. The rest of the file already used `with` everywhere.

Verified: scorecard output identical, exit 0, all 5 harness/demo tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_