### PR TITLE
Set AIR_MCP_RESOURCE_URL so discovery reports the server, not the IdP

### DIFF
--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -23,6 +23,10 @@ primary_region = "iad"
   # The OAuth issuer claude.ai discovers during connector setup — points at
   # the IdP (WorkOS AuthKit), not at this server.
   AIR_MCP_ISSUER_URL = "https://active-midnight-15-staging.authkit.app"
+  # This server's own identity in the discovery document (RFC 9728
+  # "resource"). Must match AIR_MCP_JWT_AUDIENCE so tokens requested for
+  # this resource pass the audience pin.
+  AIR_MCP_RESOURCE_URL = "https://mcp.airblackbox.ai"
   # Hosts the server trusts (DNS-rebinding protection). Include the raw
   # fly.dev hostname so you can test before the custom domain is wired.
   AIR_MCP_ALLOWED_HOSTS = "air-mcp.fly.dev,mcp.airblackbox.ai"


### PR DESCRIPTION
## What

Follow-up to #70, caught during live verification of the deployed server. The discovery document currently reports:

```json
{"resource":"https://active-midnight-15-staging.authkit.app/", ...}
```

The `resource` field (RFC 9728) must identify **this server**, not the identity provider — clients validate it against the URL they connected to, and it's the RFC 8707 resource indicator they request tokens for. It was inheriting the issuer because `AIR_MCP_RESOURCE_URL` defaults to `AIR_MCP_ISSUER_URL`.

## Fix

One line in `deploy/mcp/fly.toml`: pin `AIR_MCP_RESOURCE_URL = "https://mcp.airblackbox.ai"`, matching `AIR_MCP_JWT_AUDIENCE` so tokens requested for this resource pass the audience pin. After redeploy, discovery should report `resource` = the server, `authorization_servers` = AuthKit.

Config only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_