### PR TITLE
Give the hosted MCP server a real monitoring story

### DIFF
--- a/deploy/mcp/Dockerfile
+++ b/deploy/mcp/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.12-slim
 WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY sdk/ sdk/
-RUN pip install --no-cache-dir ".[mcp,gate]"
+RUN pip install --no-cache-dir ".[mcp,gate,monitor]"
 
 # Records persist here; mount a volume in production.
 ENV AIR_RUNS_DIR=/data/runs \

--- a/deploy/mcp/fly.toml
+++ b/deploy/mcp/fly.toml
@@ -62,3 +62,13 @@ primary_region = "iad"
   force_https = true
   auto_stop_machines = false
   min_machines_running = 1
+
+  # /health write-probes the runs volume, so a failing check means "cannot
+  # record evidence" (full/unmounted/read-only volume, wedged process) and
+  # Fly restarts the machine instead of routing traffic into a black hole.
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "15s"
+    method = "GET"
+    path = "/health"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ pdf = ["reportlab>=4.0"]
 gate = ["cryptography>=42.0"]
 lake = ["pyarrow>=14.0"]  # Parquet lake sink + in-lake chain verification
 mcp = ["mcp>=1.0,<2", "pyjwt>=2.8"]  # governance MCP server for Claude (record/enforce/prove); <2: mcp 2.0 removed mcp.server.fastmcp (see #59 follow-up)
+monitor = ["sentry-sdk>=2.0"]  # optional error tracking for hosted deployments; engaged only when SENTRY_DSN is set
 # Post-quantum ML-DSA-65 signing (opt-in). pqcrypto wraps PQClean and ships
 # prebuilt wheels, so this installs (and is CI-testable) without a native
 # toolchain. NOTE: the previous pin here ("oqs") was the WRONG PyPI package -

--- a/sdk/air_blackbox/mcp_auth.py
+++ b/sdk/air_blackbox/mcp_auth.py
@@ -136,9 +136,13 @@ class JwtTokenVerifier(TokenVerifier):
             # PyJWKClient does blocking I/O on a JWKS cache miss; keep it off
             # the event loop.
             return await anyio.to_thread.run_sync(self._verify, token)
-        except Exception:
+        except Exception as exc:
             # Malformed token, bad signature, expired, wrong iss/aud, JWKS
-            # unreachable - all are "not authenticated", never a crash.
+            # unreachable - all are "not authenticated", never a crash. But
+            # the REASON must be visible to the operator (never the token
+            # itself): a fleet of silent 401s from an audience or issuer
+            # mismatch is otherwise undiagnosable from the logs.
+            logger.info("token rejected: %s: %s", type(exc).__name__, exc)
             return None
 
 
@@ -157,12 +161,15 @@ class IntrospectionTokenVerifier(TokenVerifier):
             async with httpx.AsyncClient(timeout=5.0) as client:
                 resp = await client.post(self._url, data={"token": token},
                                          headers=headers)
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
+            logger.info("introspection unreachable: %s", exc)
             return None
         if resp.status_code != 200:
+            logger.info("introspection returned HTTP %d", resp.status_code)
             return None
         data = resp.json()
         if not data.get("active"):
+            logger.info("token rejected: introspection reports inactive")
             return None
         exp = data.get("exp")
         if exp and exp < time.time():

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -140,8 +140,26 @@ app = FastMCP("air-blackbox", instructions=_INSTRUCTIONS,
 
 @app.custom_route("/health", methods=["GET"])
 async def _health(request):
-    """Unauthenticated liveness probe for load balancers / Fly health checks."""
+    """Unauthenticated health probe for load balancers / Fly health checks.
+
+    "ok" means the server can actually do its job - record evidence - not
+    merely that the process exists, so the probe write-tests the runs root
+    (the volume in production). 503 turns an invisible full/unmounted/
+    read-only volume into a failing check the platform acts on.
+    """
     from starlette.responses import JSONResponse
+    try:
+        os.makedirs(RUNS_DIR, exist_ok=True)
+        probe = os.path.join(RUNS_DIR, ".health-probe")
+        with open(probe, "w") as f:
+            f.write("ok")
+        os.remove(probe)
+    except OSError as exc:
+        logger.error("health probe cannot write runs dir %s: %s", RUNS_DIR, exc)
+        return JSONResponse(
+            {"status": "degraded", "service": "air-blackbox-mcp",
+             "detail": "runs storage not writable"},
+            status_code=503)
     return JSONResponse({"status": "ok", "service": "air-blackbox-mcp"})
 
 
@@ -1034,6 +1052,30 @@ def _start_auto_export():
     return t
 
 
+def _init_error_tracking():
+    """Optional Sentry error tracking, engaged only when SENTRY_DSN is set.
+
+    A no-op for self-hosters (no DSN, no dependency needed). For the hosted
+    deployment it is the "know before the customer does" layer: unhandled
+    exceptions are reported with stack traces instead of dying silently in
+    ephemeral platform logs. Records/prompts are never attached - Sentry
+    sees exceptions, not tenant data.
+    """
+    dsn = os.environ.get("SENTRY_DSN", "")
+    if not dsn:
+        return
+    try:
+        import sentry_sdk
+    except ImportError:
+        logger.warning(
+            "SENTRY_DSN is set but sentry-sdk is not installed; "
+            "pip install 'air-blackbox[monitor]'. Continuing without it.")
+        return
+    sentry_sdk.init(dsn=dsn, traces_sample_rate=0.0,
+                    send_default_pii=False)
+    logger.info("sentry error tracking enabled")
+
+
 def main():
     """Run over stdio (Claude Desktop) or HTTP (claude.ai custom connector).
 
@@ -1042,6 +1084,7 @@ def main():
     https://mcp.airblackbox.ai/mcp and add it in claude.ai as a custom
     connector. Default is stdio for local Claude Desktop use.
     """
+    _init_error_tracking()
     _start_auto_export()
     if os.environ.get("AIR_MCP_TRANSPORT", "stdio") == "http":
         app.settings.host = os.environ.get("AIR_MCP_HOST", "0.0.0.0")

--- a/sdk/tests/test_monitoring.py
+++ b/sdk/tests/test_monitoring.py
@@ -1,0 +1,73 @@
+"""Monitoring layer: the health probe must tell the truth (ok only when
+evidence can actually be recorded), auth rejections must be diagnosable from
+logs without ever logging the token, and error tracking must be a strict
+no-op unless explicitly configured.
+"""
+
+import asyncio
+import logging
+import os
+
+import pytest
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIR_RUNS_DIR", str(tmp_path / "runs"))
+    from air_blackbox import mcp_server as m
+    monkeypatch.setattr(m, "RUNS_DIR", str(tmp_path / "runs"))
+    return m
+
+
+def test_health_ok_when_volume_writable(server):
+    resp = asyncio.run(server._health(None))
+    assert resp.status_code == 200
+    assert b'"ok"' in resp.body
+
+
+def test_health_degraded_when_volume_not_writable(server, tmp_path, monkeypatch):
+    # A file where the runs DIRECTORY should be: makedirs fails with an
+    # OSError subclass, exactly like a full/unmounted/read-only volume.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a directory")
+    monkeypatch.setattr(server, "RUNS_DIR", str(blocker / "runs"))
+    resp = asyncio.run(server._health(None))
+    assert resp.status_code == 503
+    assert b"degraded" in resp.body
+    # Never leak filesystem paths to an unauthenticated endpoint.
+    assert str(blocker).encode() not in resp.body
+
+
+def test_jwt_rejection_reason_is_logged_but_token_is_not(caplog):
+    pytest.importorskip("jwt")
+    from air_blackbox.mcp_auth import JwtTokenVerifier
+    v = JwtTokenVerifier("http://127.0.0.1:9/jwks.json",
+                        issuer="https://idp.example", audience="https://api")
+    secret_token = "eyJhbGciOiJub25lIn0.SECRET-PAYLOAD.sig"
+    with caplog.at_level(logging.INFO, logger="air_blackbox.mcp_auth"):
+        assert asyncio.run(v.verify_token(secret_token)) is None
+    assert any("token rejected" in r.message for r in caplog.records)
+    assert all("SECRET-PAYLOAD" not in r.getMessage() for r in caplog.records)
+
+
+def test_error_tracking_noop_without_dsn(server, monkeypatch):
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    assert server._init_error_tracking() is None   # no crash, no import
+
+
+def test_error_tracking_missing_sdk_warns_but_does_not_crash(
+        server, monkeypatch, caplog):
+    monkeypatch.setenv("SENTRY_DSN", "https://x@example.ingest.sentry.io/1")
+    import builtins
+    real_import = builtins.__import__
+
+    def _no_sentry(name, *a, **kw):
+        if name == "sentry_sdk":
+            raise ImportError("sentry_sdk unavailable")
+        return real_import(name, *a, **kw)
+
+    monkeypatch.setattr(builtins, "__import__", _no_sentry)
+    with caplog.at_level(logging.WARNING, logger="air_blackbox.mcp"):
+        server._init_error_tracking()
+    assert any("sentry-sdk is not installed" in r.message
+               for r in caplog.records)


### PR DESCRIPTION
## What

Until tonight, if the hosted MCP server started failing, the first monitoring system to notice would have been a design partner DMing Jason. Four fixes, smallest possible footprint, all free:

**1. Fly actually runs health checks now.** `fly.toml` gains an `[[http_service.checks]]` block hitting `/health` every 30s — an unhealthy machine gets restarted instead of receiving traffic. Previously no check was configured at all.

**2. `/health` tells the truth.** It write-probes the runs volume, so `ok` means "can record evidence," not "process exists." A full, unmounted, or read-only volume becomes a failing check (503) instead of silently accepted-and-lost records. The 503 body names no filesystem paths (unauthenticated endpoint).

**3. Auth rejections are diagnosable.** The JWT verifier swallowed every rejection with a bare `except: return None` — a fleet of 401s from an audience or issuer mismatch was invisible even with `fly logs` open. Tonight's connector debugging hit exactly this blind spot. Rejection reason (exception type + message) now logs at INFO; **the token itself is never logged** (tested). Introspection failures log likewise.

**4. Optional Sentry error tracking.** `_init_error_tracking()` engages only when `SENTRY_DSN` is set, with tracing off and PII off — a strict no-op for self-hosters, "know before the customer does" for hosted. New `[monitor]` extra; the Dockerfile installs it, so `fly secrets set SENTRY_DSN=...` is the only step to enable.

## Tests

`sdk/tests/test_monitoring.py` (5 new): health ok/degraded paths including no-path-leak; rejection reason logged but token never; error tracking no-op without DSN; warns-but-doesn't-crash when the SDK is absent.

Suite: **328 passed, 8 skipped** (ML-DSA skips run in the pqc CI job).

## After merge (deploy side)

`git pull && fly deploy -a air-mcp -c deploy/mcp/fly.toml` picks up the health check + Sentry-capable image. Optionally `fly secrets set -a air-mcp SENTRY_DSN=<dsn>` to turn on error reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_