### PR TITLE
Release 1.14.0 — publish the work that was never shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-04
+
+First release since 1.13.2. Everything below was already merged to `main` but
+had never been published: a `pip install air-blackbox` was still getting a
+build from before the security review, with no anchoring, no evidence
+verification, and no `air-blackbox-mcp` / `air-evidence` commands. Releases are
+now gated by CI on the built artifact actually importing and running, so the
+published package cannot drift silently from the repo again.
+
+**Added**
+- **Public transparency-log anchoring (M2).** Exports can publish the chain head
+  to Rekor, Sigstore's public append-only log (`AIR_REKOR=1`, opt-in). The new
+  `audit_public_log` tool re-derives the bounded chain head against *every*
+  entry ever logged under the tenant's anchoring key, so an operator who
+  rewrites history **and** re-anchors it is still caught by the older entries —
+  closing the documented gap in the RFC 3161 anchor alone. Entries carry the
+  full payload inline, so any auditor can interpret them from the public log
+  with nothing but the anchoring public key (ADR 0002).
+- **ML-DSA-65 (FIPS 204) receipts are now usable.** The signer persists and
+  reloads its keypair, so a tenant's post-quantum public key survives a restart;
+  previously it regenerated on every construction and silently broke receipt
+  continuity. The post-quantum path now runs the full suite in CI. Ed25519
+  remains the default. Closes #63.
+- **A runnable proof harness** (`python bench/proof/prove.py`): executes five
+  real attacks against a plain log, a bare hash chain, and AIR side by side and
+  prints a scorecard. CI asserts both that AIR delivers every guarantee and that
+  the bare hash chain still *misses* the operator rewrite, so the comparison
+  cannot quietly become a rigged demo.
+- **"Audit Day" demo** (`demo/hiring_audit_day.py`) plus a 90-second recording
+  script — the operator-rewrite catch dramatized on a fictional hiring pipeline,
+  running real product code.
+- **Cryptographic posture document** (`docs/security/cryptographic-posture.md`):
+  the primitives in use, what each is exposed to (including quantum), how the
+  system replaces one without a rewrite, and what is not yet production-ready.
+- Scheduled auto-export: every tenant with new records gets a fresh signed
+  evidence bundle on an interval, without anyone remembering to ask.
+- Static dependency discovery for AI-BOM output from requirements.txt,
+  pyproject.toml, package.json and package-lock.json, with configurable
+  AI-library classification and CycloneDX 1.6 / SPDX 2.3 JSON output for
+  `air-blackbox discover`.
+
 **Security**
 - Receipt authenticity anchoring (remaining #57 items): `verify_receipt()` accepts an `expected_public_key` so it can reject a receipt signed by an untrusted key (without it, it only proves self-consistency — an attacker can embed their own key); the evidence bundle verifier now requires every receipt to be signed by the **same** key that signed the manifest; and `verify_chain()` reports its `key_source`, with docs making clear the colocated `.air-signing-key` is a zero-config convenience, not a trust anchor against a runs-dir writer (pair with `verify_anchor`).
 - Gate covenant conditions now fail **closed**. An ordering comparison on a non-numeric value (e.g. `amount <= 1000` with `amount="1,000,000"`), an unparseable guard, and a `forbid` whose guarded field is missing previously all defaulted to *allow*; they now deny (and a `forbid` with an indeterminate guard stays active). `Gate.walk_delegation_chain` no longer infinite-loops on a cyclic parent link, and `Gate.verify()` surfaces `authorized`/`decision` so a valid signature on a *denied* action isn't mistaken for permission. Fixes #58.
@@ -14,19 +55,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP tenant isolation: the authenticated-subject → tenant-directory mapping is now injective (readable prefix + SHA-256 of the full subject). The previous fold-and-truncate mapping could collide two different subjects onto one tenant (e.g. `alice@corp.com` ≡ `alice_corp_com`, or any two subjects sharing a 64-char prefix), and could route an authenticated subject into the shared `_local` root or the `public-demo` chain. Fixes #56.
 - MCP JWT auth now **refuses to start** in JWKS mode unless `AIR_MCP_JWT_AUDIENCE` is set (or `AIR_MCP_JWT_ALLOW_ANY_AUDIENCE=1` is explicitly set). Previously, a JWKS-only config accepted any validly-signed token from the IdP, including one minted for a different API behind the same tenant (confused-deputy replay). Static tokens without an explicit subject now derive it from a hash of the full token instead of a 12-char prefix (prefix-sharing tokens no longer collapse onto one tenant), and malformed empty-token entries are skipped. Part of #59.
 
-**Added**
-- Add static dependency discovery for AI-BOM output from requirements.txt, pyproject.toml, package.json, and package-lock.json.
-- Add configurable AI-library dependency classification.
-- Add CycloneDX 1.6 and SPDX 2.3 JSON output for `air-blackbox discover`.
-
 **Changed**
 - `air-blackbox discover --init-registry` now writes `approved-models.json`; `--approved` continues to accept JSON and existing YAML registries.
 - MCP OAuth: JWT/JWKS verification mode (`AIR_MCP_JWKS_URL`, `AIR_MCP_JWT_ISSUER`, `AIR_MCP_JWT_AUDIENCE`) — validates IdP-signed tokens locally against published JWKS (WorkOS AuthKit, Auth0, Okta, Keycloak); `pyjwt` added to the `mcp` extra
 - Deploy walkthrough for turning on authentication with a DCR-capable IdP so claude.ai custom connectors can log real users in
+- README no longer implies the chain is post-quantum secure today; it states Ed25519 now with an ML-DSA-65 upgrade path, and links the posture document.
+- Hosted MCP server monitoring: Fly now runs a health check (none was configured before), `/health` write-probes the runs volume so "ok" means "can record evidence" rather than "process is up" (503 otherwise), and optional Sentry error reporting engages only when `SENTRY_DSN` is set — a no-op for self-hosters. New `monitor` extra.
+- `mcp` extra pinned to `mcp>=1.0,<2`: mcp 2.0 removed `mcp.server.fastmcp`, which the server imports.
 
 **Fixed**
+- `air-blackbox-comply-strict` was broken in every install: the console script pointed at `air_blackbox.precommit:main`, which was never defined, so running it raised `ImportError` immediately. The entry point now exists (and supports `--help`); the hook itself was fine, only its entry point was missing. Releases now resolve every declared console script, not just import its module, so this class of break cannot ship again.
 - MCP tenant resolution now fails closed: with auth enabled, a request without an authenticated subject is denied instead of silently recorded into the shared `_local` chain
 - Auto-export logs a warning when tenant discovery or a tenant's export state is unreadable (previously silent)
+- MCP JWT rejections now log the reason (never the token). A fleet of 401s caused by an audience or issuer mismatch was previously invisible in logs, making a misconfigured deployment undiagnosable.
+- `AIR_MCP_RESOURCE_URL` is set explicitly so OAuth discovery reports this server as the protected resource rather than inheriting the IdP's URL, which broke resource-indicator matching for MCP clients.
 
 ## [1.6.1] - 2026-03-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "air-blackbox"
-version = "1.13.2"
+version = "1.14.0"
 description = "AI governance control plane - compliance, inventory, incident response, and audit for AI agents"
 readme = "sdk/README.md"
 license = "Apache-2.0"

--- a/sdk/air_blackbox/__init__.py
+++ b/sdk/air_blackbox/__init__.py
@@ -11,7 +11,7 @@ One install. Four commands. 79% automated compliance.
     air-blackbox export      # Signed evidence bundle for auditors
 """
 
-__version__ = "1.13.2"
+__version__ = "1.14.0"
 __all__ = ["AirBlackbox", "AirTrust"]
 
 

--- a/sdk/air_blackbox/precommit.py
+++ b/sdk/air_blackbox/precommit.py
@@ -6,6 +6,7 @@ issues before code is committed.
 
 import logging
 import subprocess
+import sys
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 
@@ -132,3 +133,22 @@ def execute_precommit_hook(file_paths: Optional[List[str]] = None) -> int:
     except (ValueError, subprocess.TimeoutExpired) as e:
         logger.error(f"precommit_hook_error: {e}")
         return 1
+
+
+def main() -> int:
+    """Console-script entry point for `air-blackbox-comply-strict`.
+
+    Declared in pyproject as `air_blackbox.precommit:main`, but never defined -
+    so the installed command raised ImportError on every invocation. pre-commit
+    passes the staged filenames as positional arguments; with none given,
+    execute_precommit_hook falls back to its own discovery.
+    """
+    args = sys.argv[1:]
+    if args and args[0] in ("-h", "--help"):
+        print("usage: air-blackbox-comply-strict [FILE ...]\n\n"
+              "Strict pre-commit compliance gate. Scans the given files (or the\n"
+              "staged files when none are given) and exits non-zero if the commit\n"
+              "should be blocked. Intended to be run by pre-commit, which passes\n"
+              "the staged filenames as arguments.")
+        return 0
+    return execute_precommit_hook(args or None)


### PR DESCRIPTION
## Why

PyPI `air-blackbox` has been stuck at **1.13.2** while **54 commits** landed on `main` — the entire security review, Evidence Bundle v1, M1/M2 anchoring, ML-DSA persistence. The repo carried the same version number throughout, so nothing flagged the divergence.

Today, `pip install air-blackbox` gets you a package with **no** `anchor/head.py`, **no** `evidence_verify.py`, **no** `mcp_auth.py`, and neither the `air-blackbox-mcp` nor `air-evidence` command. The README's headline guarantee — catching an operator who rewrites and re-signs history — is not in the package anyone can actually install.

## What's here

- **1.13.2 → 1.14.0** in `pyproject.toml` and `air_blackbox.__init__` (new features, not just fixes)
- **CHANGELOG**: `[Unreleased]` → a dated `1.14.0` entry, plus the work it hadn't recorded — M2 public transparency-log anchoring, ML-DSA-65 key persistence, the proof harness, the Audit Day demo, the cryptographic posture doc, and hosted-server monitoring

## Plus a bug found while stress-testing this candidate

`air-blackbox-comply-strict` raised `ImportError` on **every** invocation — its console script pointed at `air_blackbox.precommit:main`, which was never defined. The hook itself worked; only its entry point was missing. `main()` now exists and handles `--help` (it previously reported `File does not exist: --help`).

This is broken in the published 1.13.2 too, so the release fixes it for everyone.

## Verified against the built 1.14.0 wheel, installed clean with extras

| Check | Result |
|---|---|
| Version across pyproject / `__init__` / sdist / wheel | all `1.14.0` |
| All 4 console scripts resolve **and** execute | ✅ |
| `anchor.head`, `anchor.tsa`, `anchor.rekor`, `evidence_verify`, `mcp_auth`, `gate.covenant`, `mcp_server` present | ✅ |
| Full test suite against the installed wheel | **328 passed** |
| `bench/proof/prove.py` | full scorecard, exit 0 |

## Merge order

Land #73 (the release gate) first, so this release is the first one published through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_