### PR TITLE
Add /ingest: server-to-server event intake for apps that cannot own the chain

### DIFF
--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -411,11 +411,23 @@ def _ingest_write(tenant: str, event: dict):
     detail = str(event.get("detail") or "")
     category = str(event.get("category") or "")
 
+    # Retrospective policy check, NOT enforcement. This event already
+    # happened inside the caller's system; the server cannot block it and
+    # must not claim to have. So status never says "blocked" here, and the
+    # MCP session's default-deny does not apply: a vocabulary miss is
+    # recorded as "no_rule" rather than forbid, because default-denying a
+    # foreign app's completed action would fabricate an enforcement event
+    # that never occurred - in a chain whose whole point is not lying.
+    # A real forbid rule IS recorded ("this happened and tenant policy
+    # forbids it") - that verdict is evidence, the block claim would not be.
     decision = "permit"
     if _covenant:
-        decision = _covenant.evaluate(action, {
-            "model": "", "tokens_total": 0,
-            "category": category, "detail": detail}).value
+        context = {"model": "", "tokens_total": 0,
+                   "category": category, "detail": detail}
+        if _rule_exists(action, context):
+            decision = _covenant.evaluate(action, context).value
+        else:
+            decision = "no_rule"
 
     record = {
         "run_id": str(uuid.uuid4()),
@@ -427,7 +439,7 @@ def _ingest_write(tenant: str, event: dict):
         "action": action,
         "detail": detail[:2000],
         "model": "",
-        "status": "blocked" if decision == "forbid" else "success",
+        "status": "success",
         "covenant_decision": decision,
         "tokens": {"total": 0},
     }

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -20,13 +20,22 @@ Claude Desktop config:
     "args": ["-m", "air_blackbox.mcp_server"]}}}
 """
 
+import contextlib
+import glob
 import hashlib
+import hmac
 import json
 import logging
 import os
+import threading
 import uuid
 from datetime import datetime, timezone
 from typing import Optional
+
+try:                      # POSIX only; the server ships in a Linux container.
+    import fcntl
+except ImportError:       # pragma: no cover - Windows dev boxes
+    fcntl = None
 
 logger = logging.getLogger("air_blackbox.mcp")
 
@@ -256,6 +265,281 @@ async def _demo_status(request):
     """Current public-demo chain state (records + integrity verdict)."""
     from starlette.responses import JSONResponse
     return JSONResponse(_demo_chain_state(), headers=_DEMO_CORS)
+
+
+# ---------------------------------------------------------------------------
+# Ingest - server-to-server intake for apps that cannot own the chain.
+#
+# AuditChain is a single-writer design: its lock is a threading.Lock and
+# resume() replays the whole history to recover prev_hash. A serverless app
+# (Vercel functions, Lambda) violates both assumptions - the filesystem is
+# ephemeral, and concurrent invocations would each resume from the same
+# prev_hash and claim the same chain_seq, forking the chain into something
+# that can never verify. That failure is silent, which makes it worse than a
+# crash.
+#
+# So the app keeps a durable outbox and POSTs batches here, and THIS process
+# is the single writer. Two properties make that safe:
+#
+#   Idempotency - an outbox retries (timeouts, cold starts mid-flush), so the
+#   same event_id will arrive more than once. A redelivered duplicate would
+#   append a phantom record and still verify clean. Every event therefore
+#   carries a client-generated event_id; a repeat returns the original
+#   receipt_id and writes nothing.
+#
+#   Exclusivity - a second writer process (extra worker, second machine on a
+#   shared volume) is refused with 409 rather than allowed to fork the chain.
+#   A client outbox retries a 409 cleanly; a forked chain is unrecoverable.
+# ---------------------------------------------------------------------------
+
+#: Cap on one flush so a runaway outbox cannot hold the writer lock forever.
+_INGEST_MAX_EVENTS = 100
+
+_ingest_locks: dict = {}          # tenant -> threading.Lock
+_ingest_locks_guard = threading.Lock()
+_ingest_index_cache: dict = {}    # tenant -> {event_id: receipt_id}
+
+
+class _ChainBusy(Exception):
+    """Another process holds this tenant's write lock."""
+
+
+def _ingest_tokens() -> dict:
+    """Parse AIR_INGEST_TOKENS ("token:tenant,token2:tenant2") -> {token: tenant}.
+
+    Tokens are bound to a tenant here rather than trusting the tenant in the
+    request body, so a leaked token cannot write into another tenant's chain.
+    """
+    out = {}
+    for pair in os.environ.get("AIR_INGEST_TOKENS", "").split(","):
+        pair = pair.strip()
+        if not pair or ":" not in pair:
+            continue
+        token, tenant = pair.split(":", 1)
+        if token.strip() and tenant.strip():
+            out[token.strip()] = tenant.strip()
+    return out
+
+
+def _ingest_auth(request):
+    """-> (tenant, None) on success, or (None, (status, message))."""
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("bearer "):
+        return None, (401, "missing bearer token")
+    presented = header[7:].strip()
+    tokens = _ingest_tokens()
+    if not tokens:
+        # Unconfigured is a deployment state, not a bad credential: say so
+        # plainly instead of making the caller debug their token.
+        return None, (503, "ingest is not configured on this server")
+    matched = None
+    for token, tenant in tokens.items():
+        # compare_digest on every candidate: no early exit, so response time
+        # does not leak which prefix was right.
+        if hmac.compare_digest(token, presented):
+            matched = tenant
+    if matched is None:
+        return None, (401, "invalid token")
+    return matched, None
+
+
+def _ingest_index(tenant: str) -> dict:
+    """{event_id: receipt_id} for everything already ingested for a tenant.
+
+    Rebuilt from the records themselves rather than a side index, so it can
+    never drift from the chain it is supposed to describe. Read once per
+    tenant per process, then kept current in memory by the writer.
+    """
+    index = _ingest_index_cache.get(tenant)
+    if index is None:
+        index = {}
+        pattern = os.path.join(_tenant_runs_dir(tenant), "*.air.json")
+        for path in glob.glob(pattern):
+            try:
+                with open(path) as f:
+                    record = json.load(f)
+            except (OSError, json.JSONDecodeError):
+                continue
+            event_id = record.get("event_id")
+            if event_id:
+                index[event_id] = (record.get("receipt") or {}).get(
+                    "receipt_id", "")
+        _ingest_index_cache[tenant] = index
+    return index
+
+
+@contextlib.contextmanager
+def _ingest_writer_lock(tenant: str):
+    """Serialize writes to one tenant's chain.
+
+    Threads queue on the in-process lock; a competing PROCESS is refused
+    outright (409) rather than queued, because a writer that waits behind an
+    unknown holder is indistinguishable from one that is about to fork the
+    chain. Fail closed: the client still holds the events.
+    """
+    with _ingest_locks_guard:
+        lock = _ingest_locks.setdefault(tenant, threading.Lock())
+    with lock:
+        runs = _tenant_runs_dir(tenant)
+        os.makedirs(runs, exist_ok=True)
+        if fcntl is None:                     # pragma: no cover
+            yield
+            return
+        handle = open(os.path.join(runs, ".air-ingest.lock"), "w")
+        try:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                raise _ChainBusy()
+            yield
+        finally:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            handle.close()
+
+
+def _ingest_write(tenant: str, event: dict):
+    """Chain one ingested event. Returns (receipt_id, chain_hash).
+
+    occurred_at is preserved separately from the server's write timestamp:
+    with an outbox those genuinely differ, and the audit story needs when the
+    decision was MADE, not when it happened to drain.
+    """
+    action = str(event.get("action") or "").strip() or "agent_action"
+    detail = str(event.get("detail") or "")
+    category = str(event.get("category") or "")
+
+    decision = "permit"
+    if _covenant:
+        decision = _covenant.evaluate(action, {
+            "model": "", "tokens_total": 0,
+            "category": category, "detail": detail}).value
+
+    record = {
+        "run_id": str(uuid.uuid4()),
+        "event_id": str(event["event_id"]).strip(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "occurred_at": str(event.get("occurred_at") or ""),
+        "type": "agent_action",
+        "source": "ingest",
+        "action": action,
+        "detail": detail[:2000],
+        "model": "",
+        "status": "blocked" if decision == "forbid" else "success",
+        "covenant_decision": decision,
+        "tokens": {"total": 0},
+    }
+    # Pass structured blocks through untouched. screening is what the
+    # evidence bundle categorizes on; attributes is the caller's own
+    # vocabulary, which this server deliberately does not interpret.
+    for key in ("screening", "attributes"):
+        if isinstance(event.get(key), dict):
+            record[key] = event[key]
+    if _covenant:
+        record["covenant_hash"] = _covenant.hash
+    record["receipt"] = _sign_receipt(tenant, action, decision, detail,
+                                      category)
+    chain_hash = _tenant_chain(tenant).write(record)
+    return record["receipt"].get("receipt_id", ""), chain_hash
+
+
+@app.custom_route("/ingest", methods=["POST"])
+async def _ingest(request):
+    """Accept a batch of events from an application and chain them.
+
+    Body: {"tenant": ..., "events": [{"event_id", "action", "detail",
+    "category", "occurred_at", "screening"?, "attributes"?}, ...]}
+    Returns: {"results": [{"event_id", "receipt_id", "chain_hash",
+    "duplicate"?}, ...]} in request order.
+    """
+    from starlette.responses import JSONResponse
+
+    tenant_for_token, err = _ingest_auth(request)
+    if err:
+        return JSONResponse({"error": err[1]}, status_code=err[0])
+
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "body must be JSON"}, status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "body must be a JSON object"},
+                            status_code=400)
+
+    tenant = str(body.get("tenant") or "").strip()
+    if not tenant:
+        return JSONResponse({"error": "tenant is required"}, status_code=400)
+    if tenant != tenant_for_token:
+        return JSONResponse(
+            {"error": "token is not valid for this tenant"}, status_code=403)
+
+    events = body.get("events")
+    if not isinstance(events, list) or not events:
+        return JSONResponse({"error": "events must be a non-empty array"},
+                            status_code=400)
+    if len(events) > _INGEST_MAX_EVENTS:
+        return JSONResponse(
+            {"error": f"batch too large (max {_INGEST_MAX_EVENTS} events)"},
+            status_code=413)
+    # Validate the whole batch before writing any of it, so a malformed
+    # tail cannot leave a half-written flush the client must reconcile.
+    for event in events:
+        if not isinstance(event, dict):
+            return JSONResponse({"error": "each event must be an object"},
+                                status_code=400)
+        if not str(event.get("event_id") or "").strip():
+            return JSONResponse(
+                {"error": "every event needs an event_id (idempotency key)"},
+                status_code=400)
+
+    results = []
+    try:
+        with _ingest_writer_lock(tenant):
+            index = _ingest_index(tenant)
+            for event in events:
+                event_id = str(event["event_id"]).strip()
+                if event_id in index:
+                    results.append({"event_id": event_id,
+                                    "receipt_id": index[event_id],
+                                    "duplicate": True})
+                    continue
+                receipt_id, chain_hash = _ingest_write(tenant, event)
+                index[event_id] = receipt_id
+                results.append({"event_id": event_id,
+                                "receipt_id": receipt_id,
+                                "chain_hash": chain_hash})
+    except _ChainBusy:
+        return JSONResponse(
+            {"error": "chain unavailable: another writer holds this tenant"},
+            status_code=409)
+
+    logger.info("ingest tenant=%s events=%d written=%d", tenant, len(events),
+                sum(1 for r in results if not r.get("duplicate")))
+    return JSONResponse({"results": results})
+
+
+@app.custom_route("/ingest/status", methods=["GET"])
+async def _ingest_status(request):
+    """Chain state for the authenticated tenant, so a caller's own health
+    endpoint can confirm events are actually landing here."""
+    from starlette.responses import JSONResponse
+
+    tenant, err = _ingest_auth(request)
+    if err:
+        return JSONResponse({"error": err[1]}, status_code=err[0])
+    engine = ReplayEngine(runs_dir=_tenant_runs_dir(tenant))
+    total = engine.load()
+    result = engine.verify_chain()
+    ingested = len(_ingest_index(tenant))
+    return JSONResponse({
+        "tenant": tenant,
+        "records": total,
+        "ingested_events": ingested,
+        "chain_intact": bool(result.intact),
+        "single_writer": fcntl is not None,
+    })
 
 
 def _rule_exists(action: str, context: dict) -> bool:

--- a/sdk/tests/test_mcp_ingest.py
+++ b/sdk/tests/test_mcp_ingest.py
@@ -321,3 +321,60 @@ def _only_record(server):
     assert len(paths) == 1, f"expected exactly one record, got {len(paths)}"
     with open(paths[0]) as f:
         return json.load(f)
+
+
+# ---- covenant interaction ------------------------------------------------
+# The deployed server runs with AIR_COVENANT set. Ingest must treat that
+# covenant as a retrospective second opinion, never as enforcement: the
+# events already happened in the caller's system.
+
+@pytest.fixture
+def governed_server(tmp_path, monkeypatch):
+    covenant = os.path.join(
+        os.path.dirname(__file__), "..", "air_blackbox", "gate", "examples",
+        "recruiting-screener.covenant.yaml")
+    monkeypatch.setenv("AIR_RUNS_DIR", str(tmp_path / "runs"))
+    monkeypatch.setenv("AIR_INGEST_TOKENS", "tok-a:sourcingnav")
+    monkeypatch.setenv("AIR_COVENANT", os.path.abspath(covenant))
+    import importlib
+
+    from air_blackbox import mcp_server as m
+    importlib.reload(m)
+    assert m._covenant is not None
+    return m
+
+
+def test_vocabulary_miss_is_no_rule_not_a_fabricated_block(governed_server):
+    """define_search_criteria has no rule in the recruiting covenant. The
+    MCP session path default-denies unknown names; applied to ingest that
+    would record a foreign app's completed action as 'blocked' - an
+    enforcement event that never happened, in a tamper-evident chain."""
+    r = _post(governed_server, _payload(governed_server,
+                                        [_event("e1",
+                                                action="define_search_criteria")]))
+    assert r.status_code == 200
+    record = _only_record(governed_server)
+    assert record["status"] == "success"
+    assert record["covenant_decision"] == "no_rule"
+
+
+def test_matched_rule_verdict_is_recorded_without_blocking(governed_server):
+    """reject_candidate is require_approval in the covenant. The verdict is
+    evidence; the event still records as what it was - a completed action."""
+    _post(governed_server, _payload(governed_server,
+                                    [_event("e1", action="reject_candidate")]))
+    record = _only_record(governed_server)
+    assert record["status"] == "success"
+    assert record["covenant_decision"] == "require_approval"
+
+
+def test_forbidden_action_records_the_verdict_and_the_fact(governed_server):
+    """The strongest sample: the caller reports an action tenant policy
+    forbids. Honest record = it happened AND policy forbids it. Claiming
+    it was blocked would be the lie."""
+    _post(governed_server, _payload(
+        governed_server,
+        [_event("e1", action="infer_protected_attributes")]))
+    record = _only_record(governed_server)
+    assert record["status"] == "success"
+    assert record["covenant_decision"] == "forbid"

--- a/sdk/tests/test_mcp_ingest.py
+++ b/sdk/tests/test_mcp_ingest.py
@@ -1,0 +1,323 @@
+"""Tests for the /ingest endpoint - server-to-server event intake.
+
+The endpoint exists because AuditChain is a single-writer design and a
+serverless caller cannot be one: ephemeral disk loses records, and concurrent
+invocations fork the chain. Both failures are silent, so these tests assert
+the two properties that keep them from happening here - idempotency across
+outbox redelivery, and exclusivity against a second writer.
+"""
+
+import asyncio
+import glob
+import json
+import os
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette request (headers + json body)."""
+
+    def __init__(self, body=None, token="tok-a", raw=None):
+        self.headers = {"authorization": f"Bearer {token}"} if token else {}
+        self._body = body
+        self._raw = raw
+
+    async def json(self):
+        if self._raw is not None:
+            raise ValueError("not json")
+        return self._body
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    """Fresh module state pointed at a temp runs dir."""
+    monkeypatch.setenv("AIR_RUNS_DIR", str(tmp_path / "runs"))
+    monkeypatch.setenv("AIR_INGEST_TOKENS", "tok-a:sourcingnav,tok-b:other")
+    import importlib
+
+    from air_blackbox import mcp_server as m
+    importlib.reload(m)
+    return m
+
+
+def _post(server, body, token="tok-a"):
+    return asyncio.run(server._ingest(_FakeRequest(body, token)))
+
+
+def _payload(server, events, tenant="sourcingnav"):
+    return {"tenant": tenant, "events": events}
+
+
+def _body_of(response):
+    return json.loads(response.body)
+
+
+def _event(event_id="e1", **kw):
+    base = {
+        "event_id": event_id,
+        "action": "score_candidate",
+        "category": "screening",
+        "detail": "scored candidate against search criteria",
+        "occurred_at": "2026-08-06T16:41:37Z",
+    }
+    base.update(kw)
+    return base
+
+
+# ---- auth ----------------------------------------------------------------
+
+def test_missing_token_is_401(server):
+    r = asyncio.run(server._ingest(_FakeRequest(_payload(server, [_event()]),
+                                                token=None)))
+    assert r.status_code == 401
+
+
+def test_bad_token_is_401(server):
+    r = _post(server, _payload(server, [_event()]), token="nope")
+    assert r.status_code == 401
+
+
+def test_unconfigured_server_is_503_not_401(server, monkeypatch):
+    """An unconfigured deployment is not a bad credential - saying 401 would
+    send the caller off debugging a token that was never the problem."""
+    monkeypatch.setenv("AIR_INGEST_TOKENS", "")
+    r = _post(server, _payload(server, [_event()]))
+    assert r.status_code == 503
+
+
+def test_token_cannot_write_to_another_tenant(server):
+    """The token owns the tenant; the body cannot override it."""
+    r = _post(server, _payload(server, [_event()], tenant="other"),
+              token="tok-a")
+    assert r.status_code == 403
+
+
+# ---- happy path ----------------------------------------------------------
+
+def test_writes_events_and_returns_receipts(server):
+    r = _post(server, _payload(server, [_event("e1"), _event("e2")]))
+    assert r.status_code == 200
+    results = _body_of(r)["results"]
+    assert [x["event_id"] for x in results] == ["e1", "e2"]
+    assert all(x["receipt_id"] for x in results)
+    assert all(x["chain_hash"] for x in results)
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    assert len(glob.glob(os.path.join(runs, "*.air.json"))) == 2
+
+
+def test_results_preserve_request_order(server):
+    ids = [f"e{i}" for i in range(10)]
+    r = _post(server, _payload(server, [_event(i) for i in ids]))
+    assert [x["event_id"] for x in _body_of(r)["results"]] == ids
+
+
+def test_occurred_at_is_kept_separate_from_write_time(server):
+    """With an outbox these genuinely differ; the audit story needs when the
+    decision was made, not when the queue happened to drain."""
+    _post(server, _payload(server, [_event("e1")]))
+    record = _only_record(server)
+    assert record["occurred_at"] == "2026-08-06T16:41:37Z"
+    assert record["timestamp"] != record["occurred_at"]
+
+
+def test_screening_and_attributes_pass_through_untouched(server):
+    screening = {"decision_type": "search_criteria", "human_reviewer": "",
+                 "human_review_required": True, "covenant_flags": ["young"]}
+    attributes = {"user_id": "u_9f3c", "subject_ref": "srch_881",
+                  "model": "2026.08.05.3"}
+    _post(server, _payload(server, [
+        _event("e1", screening=screening, attributes=attributes)]))
+    record = _only_record(server)
+    assert record["screening"] == screening
+    assert record["attributes"] == attributes
+
+
+def test_chain_verifies_after_ingest(server):
+    _post(server, _payload(server, [_event(f"e{i}") for i in range(5)]))
+    from air_blackbox.replay.engine import ReplayEngine
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    engine = ReplayEngine(runs_dir=runs)
+    total = engine.load()
+    assert total == 5
+    assert engine.verify_chain().intact
+
+
+# ---- idempotency ---------------------------------------------------------
+
+def test_redelivered_event_returns_original_receipt_and_writes_nothing(server):
+    """The failure this prevents: a retried outbox flush appends a phantom
+    record, and the chain still verifies clean - wrong but internally
+    consistent, which is worse than a visible break."""
+    first = _body_of(_post(server, _payload(server, [_event("e1")])))
+    again = _body_of(_post(server, _payload(server, [_event("e1")])))
+
+    assert again["results"][0]["duplicate"] is True
+    assert again["results"][0]["receipt_id"] == first["results"][0]["receipt_id"]
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    assert len(glob.glob(os.path.join(runs, "*.air.json"))) == 1
+
+
+def test_partially_overlapping_batch_writes_only_the_new_events(server):
+    _post(server, _payload(server, [_event("e1"), _event("e2")]))
+    r = _body_of(_post(server, _payload(
+        server, [_event("e2"), _event("e3")])))
+    assert r["results"][0]["duplicate"] is True
+    assert "duplicate" not in r["results"][1]
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    assert len(glob.glob(os.path.join(runs, "*.air.json"))) == 3
+
+
+def test_idempotency_survives_process_restart(server):
+    """The index is rebuilt from the records, not held only in memory - a
+    redeploy mid-flush must not turn retries into duplicates."""
+    first = _body_of(_post(server, _payload(server, [_event("e1")])))
+    server._ingest_index_cache.clear()
+    server._chains.clear()
+    again = _body_of(_post(server, _payload(server, [_event("e1")])))
+    assert again["results"][0]["duplicate"] is True
+    assert again["results"][0]["receipt_id"] == first["results"][0]["receipt_id"]
+
+
+# ---- validation ----------------------------------------------------------
+
+def test_event_without_event_id_is_rejected(server):
+    bad = _event("e1")
+    del bad["event_id"]
+    r = _post(server, _payload(server, [bad]))
+    assert r.status_code == 400
+    assert "event_id" in _body_of(r)["error"]
+
+
+def test_malformed_tail_writes_nothing(server):
+    """Validate the whole batch first: a half-written flush would leave the
+    client reconciling which events actually landed."""
+    bad = _event("e2")
+    del bad["event_id"]
+    r = _post(server, _payload(server, [_event("e1"), bad]))
+    assert r.status_code == 400
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    assert glob.glob(os.path.join(runs, "*.air.json")) == []
+
+
+def test_empty_batch_is_rejected(server):
+    assert _post(server, _payload(server, [])).status_code == 400
+
+
+def test_oversized_batch_is_rejected(server):
+    events = [_event(f"e{i}") for i in range(server._INGEST_MAX_EVENTS + 1)]
+    assert _post(server, _payload(server, events)).status_code == 413
+
+
+def test_non_json_body_is_400(server):
+    r = asyncio.run(server._ingest(_FakeRequest(raw="garbage")))
+    assert r.status_code == 400
+
+
+# ---- exclusivity ---------------------------------------------------------
+
+def test_second_writer_gets_409_instead_of_forking_the_chain(server,
+                                                             monkeypatch):
+    """A competing process is refused, not queued. The client keeps the
+    events and retries; a forked chain would be unrecoverable."""
+    real = server._ingest_writer_lock
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def busy(tenant):
+        raise server._ChainBusy()
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(server, "_ingest_writer_lock", busy)
+    r = _post(server, _payload(server, [_event("e1")]))
+    assert r.status_code == 409
+    assert "another writer" in _body_of(r)["error"]
+
+    monkeypatch.setattr(server, "_ingest_writer_lock", real)
+    assert _post(server, _payload(server, [_event("e1")])).status_code == 200
+
+
+def test_flock_is_actually_exclusive(server, tmp_path):
+    """The lock is a real advisory file lock, not just an in-process one."""
+    import fcntl
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    os.makedirs(runs, exist_ok=True)
+    held = open(os.path.join(runs, ".air-ingest.lock"), "w")
+    fcntl.flock(held.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    try:
+        with pytest.raises(server._ChainBusy):
+            with server._ingest_writer_lock("sourcingnav"):
+                pass  # pragma: no cover
+    finally:
+        fcntl.flock(held.fileno(), fcntl.LOCK_UN)
+        held.close()
+
+
+# ---- status --------------------------------------------------------------
+
+def test_status_reports_tenant_chain_state(server):
+    _post(server, _payload(server, [_event("e1"), _event("e2")]))
+    r = asyncio.run(server._ingest_status(_FakeRequest(token="tok-a")))
+    body = _body_of(r)
+    assert body["tenant"] == "sourcingnav"
+    assert body["records"] == 2
+    assert body["ingested_events"] == 2
+    assert body["chain_intact"] is True
+
+
+def test_status_requires_auth(server):
+    r = asyncio.run(server._ingest_status(_FakeRequest(token=None)))
+    assert r.status_code == 401
+
+
+# ---- the real placement-ops wire payload ---------------------------------
+
+def test_accepts_the_real_sourcingnav_payload(server):
+    """Verbatim shape emitted by placement-ops, so a change on either side
+    that breaks the contract fails here rather than in production."""
+    payload = {
+        "tenant": "sourcingnav",
+        "events": [{
+            "event_id": "9ab52593-3f09-4658-aa28-2817ca12f2b1",
+            "action": "define_search_criteria",
+            "category": "screening",
+            "detail": "senior GNC engineer, TS/SCI, young grads preferred",
+            "occurred_at": "2026-08-06T16:41:37Z",
+            "screening": {
+                "decision_type": "search_criteria",
+                "human_reviewer": "",
+                "human_review_required": True,
+                "covenant_flags": ["young"],
+            },
+            "attributes": {
+                "user_id": "u_9f3c", "subject_ref": "srch_881",
+                "inputs": {}, "outputs": {},
+                "model": "2026.08.05.3", "receipt_of": "",
+                "covenant": ["explainable_on_request", "human_before_contact",
+                             "no_autonomous_rejection",
+                             "no_protected_attribute_inference"],
+            },
+        }],
+    }
+    r = _post(server, payload)
+    assert r.status_code == 200
+    result = _body_of(r)["results"][0]
+    assert result["event_id"] == "9ab52593-3f09-4658-aa28-2817ca12f2b1"
+    assert result["receipt_id"]
+
+    record = _only_record(server)
+    # The protected-attribute proxy the caller's detector flagged must survive
+    # into the record: recording the catch is the point, not filtering it.
+    assert record["screening"]["covenant_flags"] == ["young"]
+    assert record["action"] == "define_search_criteria"
+
+
+def _only_record(server):
+    runs = os.path.join(os.environ["AIR_RUNS_DIR"], "sourcingnav")
+    paths = glob.glob(os.path.join(runs, "*.air.json"))
+    assert len(paths) == 1, f"expected exactly one record, got {len(paths)}"
+    with open(paths[0]) as f:
+        return json.load(f)


### PR DESCRIPTION
Phase 1 of instrumenting SourcingNav (placement-ops). This is the server side of the contract; the client side is placement-ops#150.

## Why an endpoint instead of `pip install`

`AuditChain` is a **single-writer design**. Its lock is a `threading.Lock` and `resume()` replays the whole history to recover `prev_hash`. A serverless caller violates both assumptions:

- Ephemeral disk loses records when the function freezes.
- Concurrent invocations each resume from the same `prev_hash` and claim the same `chain_seq`, **forking the chain** into something that can never verify.

Both failures are silent. So the app keeps a durable outbox and POSTs batches here, and this process is the one writer.

## The two properties that make it safe

**Idempotency.** An outbox retries — timeouts, cold starts mid-flush — so the same event will arrive more than once. A redelivered duplicate would append a phantom record and *still verify clean*: wrong but internally consistent, which is worse than a visible break. Every event carries a client-generated `event_id`; a repeat returns the original `receipt_id` and writes nothing.

The index is rebuilt from the records themselves rather than a side table, so it cannot drift from the chain it describes, and it survives a redeploy mid-flush (there's a test for exactly that).

**Exclusivity.** A competing writer process — extra worker, second machine on a shared volume — is refused with `409` rather than queued. A writer waiting behind an unknown holder is indistinguishable from one about to fork the chain, so this fails closed: the client still holds the events and retries cleanly.

## Contract

```
POST /ingest          Authorization: Bearer <AIR_INGEST_TOKEN>
{"tenant": "...", "events": [{event_id, action, category, detail,
                              occurred_at, screening?, attributes?}]}
→ 200 {"results": [{event_id, receipt_id, chain_hash, duplicate?}]}   (request order)
→ 400 malformed   401 bad token   403 wrong tenant
→ 409 another writer   413 batch > 100   503 ingest not configured

GET /ingest/status    → {tenant, records, ingested_events, chain_intact, single_writer}
```

Config: `AIR_INGEST_TOKENS="token:tenant,token2:tenant2"`.

Notable choices:
- **Tokens are bound to a tenant**, so the `tenant` in the body cannot widen a leaked token's reach. Constant-time compare against every candidate, no early exit.
- **`occurred_at` is separate from the write timestamp.** With an outbox those genuinely differ, and the audit story needs when the decision was *made*.
- **The whole batch validates before any of it is written**, so a malformed tail can't leave a half-written flush to reconcile.
- **`attributes` passes through uninterpreted** — the caller's vocabulary stays the caller's.

## Verification

Not just in-process. Ran a live server over HTTP:

| Check | Result |
|---|---|
| Unauthenticated POST | `401` |
| Real 2-event batch | receipts + chain hashes, correct order |
| Same batch redelivered | identical `receipt_id`s, `duplicate: true`, **zero** new records |
| Wrong tenant | `403` |
| `/ingest/status` | 2 records, `chain_intact: true` |
| Records on disk | `occurred_at` preserved and ≠ write time, `covenant_flags: ["young"]` intact, chain verifies |

**350 tests pass** (328 before, 22 new), including the verbatim placement-ops wire payload so a contract change on either side fails here rather than in production.

## Still needs a decision from the operator

`fly.toml` isn't in this repo. **If Fly ever runs two machines, the file lock does not span them** and the chain forks. This must be pinned to a single machine. The `single_writer` field in `/ingest/status` reports whether advisory locking is even available, but it cannot detect a second machine on a separate volume — that one is a deployment guarantee, not something the code can enforce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_