### PR TITLE
Fix export timing out, and let the ingesting tenant export its own evidence

### DIFF
--- a/sdk/air_blackbox/anchor/tsa.py
+++ b/sdk/air_blackbox/anchor/tsa.py
@@ -58,8 +58,16 @@ def make_query(head_hex: str) -> bytes:
 
 
 def timestamp_head(head_hex: str,
-                   tsa_urls: Optional[List[str]] = None) -> AnchorResult:
-    """Obtain an RFC 3161 timestamp over the head from the first reachable TSA."""
+                   tsa_urls: Optional[List[str]] = None,
+                   timeout: float = 20.0) -> AnchorResult:
+    """Obtain an RFC 3161 timestamp over the head from the first reachable TSA.
+
+    timeout is PER URL, and the default list holds three, so a caller that
+    must answer an interactive request should pass a smaller value: an
+    unreachable TSA otherwise costs timeout x len(urls) before returning.
+    An anchor gap is recorded honestly by the caller, so failing fast costs
+    nothing but the anchor itself.
+    """
     if not head_hex:
         return AnchorResult(ok=False, head=head_hex, error="no chain head to anchor")
     import httpx
@@ -73,7 +81,7 @@ def timestamp_head(head_hex: str,
     last_err = "no TSA reachable"
     for url in urls:
         try:
-            resp = httpx.post(url, content=tsq, timeout=20.0,
+            resp = httpx.post(url, content=tsq, timeout=timeout,
                               headers={"Content-Type": "application/timestamp-query"})
         except httpx.HTTPError as e:
             last_err = f"{url}: {e}"

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -532,6 +532,58 @@ async def _ingest(request):
     return JSONResponse({"results": results})
 
 
+@app.custom_route("/ingest/export", methods=["GET", "POST"])
+async def _ingest_export(request):
+    """Export the ingesting tenant's evidence bundle, returned as the ZIP.
+
+    export_evidence (the MCP tool) exports the tenant derived from the CHAT
+    session's OAuth subject - which is not the tenant an application ingests
+    under. An operator asking Claude to export after wiring up ingest would
+    get their own empty session chain and reasonably conclude "no records
+    yet", when the records exist under a different tenant entirely.
+
+    The ingest token is already bound to exactly one tenant, so it is the
+    right credential for exporting that tenant's evidence: no broader grant
+    is created by honoring it here.
+
+    Anchoring is bounded (see _anchor_timeout) so this answers promptly; an
+    anchor gap is recorded in the bundle rather than hidden.
+    """
+    from starlette.responses import FileResponse, JSONResponse
+
+    tenant, err = _ingest_auth(request)
+    if err:
+        return JSONResponse({"error": err[1]}, status_code=err[0])
+
+    engine = ReplayEngine(runs_dir=_tenant_runs_dir(tenant))
+    if engine.load() == 0:
+        return JSONResponse(
+            {"error": f"no records for tenant '{tenant}' - nothing to export"},
+            status_code=404)
+
+    try:
+        with _ingest_writer_lock(tenant):
+            note = _export_tenant(tenant, anchor_timeout=_anchor_timeout())
+    except _ChainBusy:
+        return JSONResponse(
+            {"error": "chain unavailable: another writer holds this tenant"},
+            status_code=409)
+
+    # _export_tenant returns prose for the chat tool; recover the path it wrote.
+    path = None
+    for token in note.replace(",", " ").split():
+        if token.endswith(".air-evidence"):
+            path = token
+            break
+    if not path or not os.path.exists(path):
+        return JSONResponse({"error": "bundle was written but could not be "
+                                      "located", "detail": note},
+                            status_code=500)
+    return FileResponse(path, media_type="application/zip",
+                        filename=os.path.basename(path),
+                        headers={"X-Air-Export-Note": note[:400]})
+
+
 @app.custom_route("/ingest/status", methods=["GET"])
 async def _ingest_status(request):
     """Chain state for the authenticated tenant, so a caller's own health
@@ -908,13 +960,17 @@ def export_evidence() -> str:
     attachments/) aligned to SB 26-189 deployer documentation duties.
     The bundle supports an impact assessment and is audit-ready; it is
     not a legal compliance determination."""
-    return _export_tenant(_current_tenant())
+    return _export_tenant(_current_tenant(), anchor_timeout=_anchor_timeout())
 
 
-def _export_tenant(tenant: str) -> str:
+def _export_tenant(tenant: str, anchor_timeout: Optional[float] = None) -> str:
     """Core evidence export for one tenant. Called by the export_evidence
     tool and by the auto-export scheduler - evidence must never depend on
-    a busy human remembering to ask for it."""
+    a busy human remembering to ask for it.
+
+    anchor_timeout bounds the external TSA call. Interactive callers pass a
+    short one so the response arrives; the scheduler passes None to wait.
+    """
     from dataclasses import asdict
 
     from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
@@ -930,7 +986,8 @@ def _export_tenant(tenant: str) -> str:
 
     # Anchor the head at an external TSA BEFORE packaging, so the timestamp
     # token travels inside the signed bundle (verifiable offline by a stranger).
-    anchor_note, anchor_manifest = _anchor_current_head(tenant)
+    anchor_note, anchor_manifest = _anchor_current_head(
+        tenant, timeout=anchor_timeout)
 
     # Deployer-supplied register info and attachments. Missing values are
     # exported as "deployer-supplied" so gaps are explicit, never hidden.
@@ -983,7 +1040,25 @@ def _anchor_dir(tenant: str) -> str:
     return d
 
 
-def _anchor_current_head(tenant: str):
+def _anchor_timeout() -> float:
+    """Per-TSA timeout for anchoring during an INTERACTIVE export.
+
+    export_evidence is called from a chat connector, which gives up long
+    before the handler does. The default TSA list holds three URLs, so the
+    old 20s-per-URL default could block a single tool call for a minute and
+    surface to the user as "the server isn't responding" - a timeout, not an
+    error, with nothing to debug. An anchor gap is already recorded honestly,
+    so a short deadline trades an optional timestamp for a response that
+    actually arrives. The 24h auto-export is not interactive and keeps the
+    patient default.
+    """
+    try:
+        return max(1.0, float(os.environ.get("AIR_ANCHOR_TIMEOUT", "6")))
+    except ValueError:
+        return 6.0
+
+
+def _anchor_current_head(tenant: str, timeout: Optional[float] = None):
     """Timestamp the current chain head at an external TSA and persist the
     token. An unreachable TSA is recorded as a gap, never silently dropped.
     Returns (note, manifest_dict) - the manifest goes into the signed bundle."""
@@ -1001,7 +1076,8 @@ def _anchor_current_head(tenant: str):
         return "Anchor: no chained records to anchor.", {"anchored": False,
                                                          "reason": "no records"}
 
-    result = timestamp_head(head, _tsa_urls())
+    result = timestamp_head(head, _tsa_urls(),
+                            timeout=timeout if timeout is not None else 20.0)
     if not result.ok:
         # An anchor gap is itself evidence - record it, do not hide it.
         with open(os.path.join(_anchor_dir(tenant), "gaps.log"), "a") as f:

--- a/sdk/tests/test_anchor.py
+++ b/sdk/tests/test_anchor.py
@@ -163,7 +163,9 @@ def _mcp_server(monkeypatch, tmp_path):
 
 def _patch_local_tsa(monkeypatch, tsa: "LocalTSA"):
     """Make the MCP server's anchor path use a local offline TSA."""
-    def fake_timestamp_head(head_hex, tsa_urls=None):
+    # **kw: tolerate the caller's optional args (e.g. the interactive
+    # anchor timeout) so a signature change cannot silently break this stub.
+    def fake_timestamp_head(head_hex, tsa_urls=None, **kw):
         return AnchorResult(ok=True, head=head_hex, tsr=tsa.reply(head_hex),
                             tsa_url="local-test-tsa", timestamp="T0")
     # export_evidence imports timestamp_head from air_blackbox.anchor at call
@@ -221,7 +223,7 @@ def test_mcp_anchor_gap_is_reported_not_hidden(tmp_path, monkeypatch):
 
     # No reachable TSA -> anchor gap.
     monkeypatch.setattr("air_blackbox.anchor.timestamp_head",
-                        lambda h, u=None: AnchorResult(
+                        lambda h, u=None, **kw: AnchorResult(
                             ok=False, head=h, error="no TSA reachable"))
     srv.record_action("read_profile")
     out = srv.export_evidence()

--- a/sdk/tests/test_mcp_ingest.py
+++ b/sdk/tests/test_mcp_ingest.py
@@ -378,3 +378,63 @@ def test_forbidden_action_records_the_verdict_and_the_fact(governed_server):
     record = _only_record(governed_server)
     assert record["status"] == "success"
     assert record["covenant_decision"] == "forbid"
+
+
+# ---- export ---------------------------------------------------------------
+# export_evidence (the chat tool) exports the SESSION's tenant, which is not
+# the tenant an app ingests under. Without this endpoint an operator asking
+# Claude to export would get an empty chain and conclude nothing was recorded.
+
+def test_export_returns_a_bundle_for_the_ingesting_tenant(server, monkeypatch):
+    monkeypatch.setenv("AIR_TSA_URLS", "http://127.0.0.1:9/none")  # fail fast
+    _post(server, _payload(server, [_event("e1"), _event("e2")]))
+    r = asyncio.run(server._ingest_export(_FakeRequest(token="tok-a")))
+    assert r.status_code == 200
+    assert r.media_type == "application/zip"
+    assert str(r.path).endswith(".air-evidence")
+
+
+def test_exported_bundle_verifies_and_holds_the_ingested_records(server,
+                                                                 monkeypatch):
+    monkeypatch.setenv("AIR_TSA_URLS", "http://127.0.0.1:9/none")
+    _post(server, _payload(server, [_event("e1"), _event("e2")]))
+    r = asyncio.run(server._ingest_export(_FakeRequest(token="tok-a")))
+
+    import zipfile
+    with zipfile.ZipFile(str(r.path)) as z:
+        names = set(z.namelist())
+        assert "manifest.json" in names
+        assert any(n.startswith("mapping/") for n in names)
+        manifest = json.loads(z.read("manifest.json"))
+        actions = z.read("records/actions.jsonl").decode().strip().splitlines()
+    assert manifest["tenant"] == "sourcingnav"
+    assert manifest["counts"]["actions"] == 2
+    assert len(actions) == 2
+
+
+def test_export_requires_auth_and_is_tenant_bound(server):
+    assert asyncio.run(
+        server._ingest_export(_FakeRequest(token=None))).status_code == 401
+    assert asyncio.run(
+        server._ingest_export(_FakeRequest(token="nope"))).status_code == 401
+
+
+def test_export_of_an_empty_tenant_is_404_not_an_empty_bundle(server):
+    """A bundle attesting nothing is worse than an honest 404 - it looks like
+    evidence."""
+    r = asyncio.run(server._ingest_export(_FakeRequest(token="tok-b")))
+    assert r.status_code == 404
+
+
+def test_anchor_timeout_is_short_by_default(server):
+    """The interactive path must answer before a chat connector gives up:
+    3 default TSAs x 20s was a minute of blocking that surfaced as 'the
+    server isn't responding'."""
+    assert server._anchor_timeout() <= 10
+
+
+def test_anchor_timeout_is_configurable(server, monkeypatch):
+    monkeypatch.setenv("AIR_ANCHOR_TIMEOUT", "3")
+    assert server._anchor_timeout() == 3.0
+    monkeypatch.setenv("AIR_ANCHOR_TIMEOUT", "garbage")
+    assert server._anchor_timeout() == 6.0


### PR DESCRIPTION
Diagnosed from a connector timeout on `export_evidence`. Two problems, and the second is the one that would have quietly misled us.

## 1. The timeout was self-inflicted

`export_evidence` anchors the chain head at an external TSA *before* packaging. `AIR_TSA_URLS` is unset in production, so it falls back to three public TSAs tried in sequence at **20s each** — up to a minute of blocking network I/O inside one tool call. A chat connector gives up long before the handler does, so the operator sees "the server isn't responding": a timeout with nothing to debug, on a server that is perfectly healthy.

`timestamp_head` now takes a per-URL `timeout`, and the interactive path passes a short one (`AIR_ANCHOR_TIMEOUT`, default 6s). An anchor gap was *already* recorded honestly in the bundle, so this trades an optional timestamp for a response that actually arrives. The 24h auto-export isn't interactive and keeps the patient default.

## 2. Export could not reach the ingested records

`export_evidence` exports the tenant derived from the **chat session's OAuth subject**. An application ingests under its own **token-bound tenant**. Different tenants, different runs directories.

So an operator who wires up ingest, asks Claude to export, and gets an empty bundle would reasonably conclude *nothing was recorded* — when the records exist, under another tenant. Neither side surfaces the mismatch. That's the failure mode this project exists to prevent, sitting in the tooling itself.

**`GET/POST /ingest/export`** closes it: authenticated by the *same* ingest token, which is already bound to exactly one tenant, so honoring it here grants nothing broader. Returns the `.air-evidence` ZIP directly.

An empty tenant returns **404, never an empty bundle** — a bundle attesting nothing still looks like evidence, which is worse than an honest miss.

```bash
curl -sO -J https://mcp.airblackbox.ai/ingest/export -H "Authorization: Bearer $TOKEN"
air-evidence verify bundle-*.air-evidence
```

## Verification

Against a live server with a deliberately unreachable TSA:

| Check | Result |
|---|---|
| Export round trip | **< 1s** (was up to 60s of blocking) |
| Bundle contents | all 3 ingested records, manifest tenant `sourcingnav` |
| Shipped verifier | all 6 checks pass |
| Anchor gap | reported as a gap, not hidden, not a failure |
| Wrong token | `401` |

**359 tests pass** (6 new). Also made two anchor-test stubs tolerate optional kwargs — they were positional-only and broke on the signature change, which is exactly the fragility a stub shouldn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_