### PR TITLE
Split adverse-decision reviewer gaps from engine outputs in the manifest

### DIFF
--- a/sdk/air_blackbox/export/evidence_bundle.py
+++ b/sdk/air_blackbox/export/evidence_bundle.py
@@ -119,6 +119,28 @@ _SCREENING_ACTIONS = frozenset(
     {"advance_candidate", "reject_candidate", "score_candidate",
      "rank_candidates", "schedule_interview"})
 
+#: Actions that END or HARM a candidacy. The explanation right and the
+#: meaningful-human-review duty (SB 26-189, California FEHA ADS rules) attach
+#: to ADVERSE outcomes, so a missing reviewer on one of these is a real
+#: compliance gap. A missing reviewer on an engine score is NOT: scoring is an
+#: input to a decision, not the decision. Counting them together buries the
+#: gaps that matter inside routine engine volume, and invites the opposite
+#: error - "fixing" the number by naming a reviewer who never reviewed
+#: anything, which would fabricate the human oversight this format exists to
+#: evidence.
+_ADVERSE_ACTIONS = frozenset({"reject_candidate"})
+
+
+def is_adverse_decision(record: Dict[str, Any]) -> bool:
+    """True if this record ends or harms a candidacy."""
+    if record.get("action") in _ADVERSE_ACTIONS:
+        return True
+    return (record.get("screening") or {}).get("decision_type") == "reject"
+
+
+def _reviewer(record: Dict[str, Any]) -> str:
+    return (record.get("screening") or {}).get("human_reviewer") or ""
+
 
 def categorize_record(record: Dict[str, Any]) -> str:
     """Map a chained record to its evidence category (see mapping/*.json)."""
@@ -227,14 +249,25 @@ def generate_evidence_bundle_v1(
     cats = [categorize_record(r) for r in chain_entries]
     screening_records = [r for r, c in zip(chain_entries, cats)
                          if c == "screening_decision"]
-    missing_reviewer = sum(
+    missing_reviewer = sum(1 for r in screening_records if not _reviewer(r))
+    adverse = [r for r in screening_records if is_adverse_decision(r)]
+    adverse_missing = sum(1 for r in adverse if not _reviewer(r))
+    engine_no_reviewer = sum(
         1 for r in screening_records
-        if not r.get("screening", {}).get("human_reviewer"))
+        if not is_adverse_decision(r) and not _reviewer(r))
     counts = {
         "actions": len(chain_entries),
         "screening_decisions": len(screening_records),
         "blocked_actions": cats.count("blocked_action"),
         "human_approvals": cats.count("human_approval"),
+        "adverse_decisions": len(adverse),
+        # The number an auditor should read first.
+        "adverse_decisions_missing_reviewer": adverse_missing,
+        # Context, not a gap: engine outputs are legitimately reviewer-less.
+        "engine_outputs_without_reviewer": engine_no_reviewer,
+        # Retained unchanged: this field predates the split and appears in
+        # already-signed bundles. Its meaning must not shift under readers of
+        # older exports, so it stays the coarse total.
         "screening_decisions_missing_reviewer": missing_reviewer,
     }
 
@@ -321,6 +354,15 @@ def generate_evidence_bundle_v1(
                            "SB 24-205, sets no explicit retention period); "
                            "computed from export time."),
         "frameworks": ["CO-SB26-189"],
+        "review_note": ("adverse_decisions_missing_reviewer is the "
+                        "compliance-relevant count: decisions that ended a "
+                        "candidacy with no named human reviewer. "
+                        "engine_outputs_without_reviewer counts scoring and "
+                        "ranking, which are inputs to a decision rather than "
+                        "the decision, and are legitimately reviewer-less. "
+                        "screening_decisions_missing_reviewer is the coarse "
+                        "total of both, kept for compatibility with bundles "
+                        "exported before the split."),
         "outcome_monitoring": "deployer-supplied",
         "anchor": anchor_manifest or {"status": "absent"},
         "files": files,

--- a/sdk/air_blackbox/mcp_server.py
+++ b/sdk/air_blackbox/mcp_server.py
@@ -1022,12 +1022,15 @@ def _export_tenant(tenant: str, anchor_timeout: Optional[float] = None) -> str:
                 f"{verification.verified_records} of {total} records verified; "
                 f"{unchained} carry no chain hash. The manifest records this. "
                 f"Tell the user.")
-    gaps = manifest["counts"]["screening_decisions_missing_reviewer"]
+    # Report only ADVERSE decisions here. Engine scores are legitimately
+    # reviewer-less, and surfacing them as "gaps" trains the operator to
+    # ignore the number that actually matters.
+    gaps = manifest["counts"]["adverse_decisions_missing_reviewer"]
     gap_note = ""
     if gaps:
-        gap_note = (f" NOTE: {gaps} screening decision(s) carry no "
-                    f"human_reviewer - flagged in the manifest as review-"
-                    f"protocol gaps; tell the user.")
+        gap_note = (f" NOTE: {gaps} decision(s) that ENDED a candidacy carry "
+                    f"no human_reviewer - flagged in the manifest as "
+                    f"review-protocol gaps; tell the user.")
     return (f"Evidence bundle written: {path} ({total} records, chain fully "
             f"verified at export time; verification stamped into the signed "
             f"manifest; verify independently with 'air-evidence verify "

--- a/tests/test_evidence_bundle_v1.py
+++ b/tests/test_evidence_bundle_v1.py
@@ -118,9 +118,17 @@ def test_categorize_record(records):
 def test_manifest_shape_and_counts(bundle):
     _, manifest = bundle
     assert manifest["bundle_version"] == "1.0"
+    # The fixture is the distinction in miniature: one reject reviewed by
+    # j.smith, one engine score with nobody assigned. The coarse total says
+    # "1 missing reviewer"; the split says the adverse decision was reviewed
+    # and the unreviewed record is an engine output, which is not a gap.
     assert manifest["counts"] == {
         "actions": 5, "screening_decisions": 2, "blocked_actions": 1,
-        "human_approvals": 1, "screening_decisions_missing_reviewer": 1}
+        "human_approvals": 1,
+        "adverse_decisions": 1,
+        "adverse_decisions_missing_reviewer": 0,
+        "engine_outputs_without_reviewer": 1,
+        "screening_decisions_missing_reviewer": 1}
     assert manifest["frameworks"] == ["CO-SB26-189"]
     assert manifest["outcome_monitoring"] == "deployer-supplied"
     assert manifest["system"]["deployer"] == "Test LLC"
@@ -249,3 +257,60 @@ def test_missing_required_file_fails_check1(bundle):
         verify_bundle(path, out=io.StringIO())
     assert e.value.check == 1
     assert "receipts.json" in e.value.message
+
+
+# ---- adverse vs engine reviewer gaps --------------------------------------
+# Production data made this concrete: 14 of 53 screening records had no
+# human_reviewer, and the coarse count invited "fixing" it by naming the
+# search-runner as the reviewer of engine scores nobody reviewed. That would
+# have fabricated human oversight inside the format that exists to evidence it.
+
+def _screening(action, reviewer="", decision_type=""):
+    return {"run_id": f"r-{action}-{reviewer}-{decision_type}",
+            "action": action, "status": "success",
+            "timestamp": "2026-08-07T00:00:00Z",
+            "screening": {"human_reviewer": reviewer,
+                          "decision_type": decision_type}}
+
+
+def test_adverse_and_engine_reviewer_gaps_are_counted_separately(signer,
+                                                                 tmp_path):
+    from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
+    records = [
+        _screening("reject_candidate", reviewer="u-abc"),   # reviewed: fine
+        _screening("reject_candidate"),                     # THE gap
+        _screening("reject_candidate"),                     # THE gap
+        _screening("score_candidate"),                      # engine: not a gap
+        _screening("score_candidate"),                      # engine: not a gap
+        _screening("rank_candidates"),                      # engine: not a gap
+    ]
+    _, manifest = generate_evidence_bundle_v1(
+        records, "t", signer, {"intact": True, "verified_records": len(records)},
+        output_dir=str(tmp_path))
+    c = manifest["counts"]
+    assert c["adverse_decisions"] == 3
+    assert c["adverse_decisions_missing_reviewer"] == 2
+    assert c["engine_outputs_without_reviewer"] == 3
+    # The coarse total keeps its old meaning for readers of older bundles.
+    assert c["screening_decisions_missing_reviewer"] == 5
+
+
+def test_decision_type_reject_counts_as_adverse_whatever_the_action_name(
+        signer, tmp_path):
+    """Callers name actions in their own vocabulary; a reject is a reject."""
+    from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
+    records = [_screening("filter_candidate", decision_type="reject")]
+    _, manifest = generate_evidence_bundle_v1(
+        records, "t", signer, {"intact": True, "verified_records": 1},
+        output_dir=str(tmp_path))
+    assert manifest["counts"]["adverse_decisions_missing_reviewer"] == 1
+
+
+def test_engine_scores_alone_report_no_adverse_gap(signer, tmp_path):
+    """A day of pure scoring must not read as a compliance problem."""
+    from air_blackbox.export.evidence_bundle import generate_evidence_bundle_v1
+    _, manifest = generate_evidence_bundle_v1(
+        [_screening("score_candidate") for _ in range(20)], "t", signer,
+        {"intact": True, "verified_records": 20}, output_dir=str(tmp_path))
+    assert manifest["counts"]["adverse_decisions_missing_reviewer"] == 0
+    assert manifest["counts"]["engine_outputs_without_reviewer"] == 20


### PR DESCRIPTION
Found by the producer side pushing back on a recommendation I made — **and they were right.**

I proposed copying `attributes.user_id` into `screening.human_reviewer` to close 14 flagged gaps in a real production bundle. That would have asserted a human reviewed calls no human saw: fabricating the human oversight this format exists to evidence. They tested first, saw that human decisions *already* populate the field correctly, and declined to implement it.

The real defect is here, in how the manifest counts.

## The problem

`screening_decisions_missing_reviewer` lumps together two unlike things:

- **`reject_candidate` with no reviewer** — an adverse decision with no human behind it. The explanation right and the meaningful-human-review duty (SB 26-189, California FEHA ADS rules) attach to adverse **outcomes**. This is a real compliance gap.
- **`score_candidate` with no reviewer** — an engine output. Scoring is an *input* to a decision, not the decision. Legitimately reviewer-less.

Counting them together does two harms:

1. **It buries the gaps that matter.** In the production bundle, 29 of 53 records are adverse decisions and 24 are search criteria and engine scores — all reported as one number.
2. **It invites the exact "fix" that was proposed to me**: make the number smaller by naming a reviewer who reviewed nothing.

## The change

```json
"adverse_decisions": 29,
"adverse_decisions_missing_reviewer": 0,      // the number an auditor reads first
"engine_outputs_without_reviewer": 14,        // context, not a gap
"screening_decisions_missing_reviewer": 14    // unchanged coarse total
```

The old field **keeps its exact meaning** — it appears in already-signed bundles and must not shift under readers of older exports. A `review_note` explains the distinction in prose, since the reader may be a lawyer rather than an engineer.

`export_evidence` now reports only the adverse count as a gap. Surfacing engine scores as "gaps" trains an operator to ignore the number that matters.

Adverse is matched by action name **or** `screening.decision_type == "reject"`, so a caller using its own vocabulary (`filter_candidate`, `pass`) is still counted correctly.

## Tests

362 pass, 4 new. The existing fixture turned out to be the distinction in miniature — one reject reviewed by `j.smith`, one engine score with nobody assigned. The coarse total says "1 missing reviewer"; the split correctly says the adverse decision *was* reviewed and the unreviewed record is an engine output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_