### PR TITLE
Remove the Article 13 coverage claim from the README (time-sensitive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Every LLM call now generates a signed, tamper-evident, replayable audit record. 
 
 **PII and injection scanning**: 20 weighted patterns across 5 attack categories detected before the prompt reaches the model. Configurable sensitivity. Auto-blocking.
 
-**EU AI Act gap analysis**: 51+ checks across Articles 9, 10, 11, 12, 13, 14, 15. Maps to ISO 42001, NIST AI RMF, and US state AI laws (Colorado SB 26-189, Illinois HB 3773, California FEHA ADS/SB 942/ADMT, Texas TRAIGA). One scan, four frameworks, one report.
+**EU AI Act gap analysis**: 51+ checks across Articles 9, 10, 11, 12, 14, 15. Maps to ISO 42001, NIST AI RMF, and US state AI laws (Colorado SB 26-189, Illinois HB 3773, California FEHA ADS/SB 942/ADMT, Texas TRAIGA). One scan, four frameworks, one report.
 
 **Replay**: load any past episode from the audit chain, verify the HMAC signature, and replay every step with timestamps. Incident reconstruction without guesswork.
 


### PR DESCRIPTION
## What does this PR do?

One line. Deletes `13, ` from the EU AI Act coverage sentence in `README.md`.

No check has ever declared Article 13. An AST walk over the two scanner modules for every literal `article=` passed to a finding constructor:

```
articles declared: [0, 9, 10, 11, 12, 14, 15, 16]
Article 13 declared anywhere: False
```

`0` is the "no Python files found" sentinel and `16` is a bucket holding US hiring law — both addressed separately in #81. The only Article 13 reference anywhere in the project is a hard-coded row in `docs/air-demo.html`, which is a demo table, not a scanner result.

## Why this is separate from #81

**It needs to merge today.** The authors of arXiv:2604.23859 (Bartz-Beielstein and Bartz, TH Köln / Bartz & Bartz GmbH) are revising their paper to cite AIR Blackbox correctly, and have stated they cite this README as the primary source at access date. They read it accurately; the README was wrong. Their v2 posts shortly, and without this it freezes a false coverage claim into an academic citation.

#81 contains the identical fix, but it is six commits of security work that deserves its own review pace. This is the one line, off `main`, so it can land immediately.

## Type of change
- [x] Bug fix
- [ ] New compliance check
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Trust layer integration

## EU AI Act articles affected

Article 13 (transparency) — removing a claim of coverage that was never implemented. No change to any check. The true covered set is Articles 9, 10, 11, 12, 14 and 15.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass
- [ ] I have added/updated docstrings where needed — n/a, no code change
- [x] My changes do not break backward compatibility

## Additional notes

This commit only stops the claim being cited. What stops it recurring is in #81: `tests/test_readme_article_coverage.py` derives the covered set from the code with `ast` and fails in both directions — an article advertised with no check behind it, and a check whose article never reaches the docs. Merging this first will not conflict with #81, which already carries the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_