### PR TITLE
Support pqcrypto 1.x — the post-quantum path broke today (fixes CI on every PR)

### DIFF
--- a/sdk/air_blackbox/gate/receipt.py
+++ b/sdk/air_blackbox/gate/receipt.py
@@ -65,10 +65,27 @@ def _oqs_mechanism():
     return "ML-DSA-65" if "ML-DSA-65" in enabled else "Dilithium3"
 
 
+def _pqcrypto_keygen():
+    """pqcrypto renamed generate_keypair() to keygen() in 1.0.0.
+
+    Both names are resolved at call time rather than pinning a version: 1.0.0
+    is the current release, and pinning below it would leave installs on an
+    old build of a cryptographic dependency, which is the wrong direction for
+    this particular library.
+    """
+    fn = getattr(_pqclean_mldsa65, "keygen", None) or \
+        getattr(_pqclean_mldsa65, "generate_keypair", None)
+    if fn is None:
+        raise RuntimeError(
+            "pqcrypto is installed but exposes neither keygen() nor "
+            "generate_keypair() for ML-DSA-65; unsupported version")
+    return fn()
+
+
 def mldsa_generate_keypair() -> tuple[bytes, bytes]:
     """Generate an ML-DSA-65 keypair. Returns (public_key, secret_key)."""
     if _MLDSA_PROVIDER == "pqcrypto":
-        pk, sk = _pqclean_mldsa65.generate_keypair()
+        pk, sk = _pqcrypto_keygen()
         return bytes(pk), bytes(sk)
     if _MLDSA_PROVIDER == "liboqs":
         sig = _oqs.Signature(_oqs_mechanism())
@@ -88,10 +105,24 @@ def mldsa_sign(secret_key: bytes, data: bytes) -> bytes:
 
 
 def mldsa_verify(public_key: bytes, data: bytes, signature: bytes) -> bool:
-    """Verify an ML-DSA-65 signature. Never raises; returns False on failure."""
+    """Verify an ML-DSA-65 signature. Never raises; returns False on failure.
+
+    The two pqcrypto generations disagree about how a *valid* signature is
+    reported, and the disagreement is silent and dangerous:
+
+        0.4.0   verify(valid) -> True     verify(invalid) -> False
+        1.0.0   verify(valid) -> None     verify(invalid) -> raises
+
+    So `bool(verify(...))` - which this used to do - turns every VALID
+    signature into False under 1.0.0. It fails closed rather than open, but it
+    would have made the post-quantum path unusable while looking like mass
+    tampering. Treat "returned without raising" as the success signal, and
+    only trust a returned value when the provider actually returns a bool.
+    """
     try:
         if _MLDSA_PROVIDER == "pqcrypto":
-            return bool(_pqclean_mldsa65.verify(public_key, data, signature))
+            result = _pqclean_mldsa65.verify(public_key, data, signature)
+            return result if isinstance(result, bool) else True
         if _MLDSA_PROVIDER == "liboqs":
             return bool(_oqs.Signature(_oqs_mechanism()).verify(
                 data, signature, public_key))

--- a/sdk/tests/test_mldsa_persistence.py
+++ b/sdk/tests/test_mldsa_persistence.py
@@ -191,3 +191,66 @@ def test_mldsa_bundle_receipt_forgery_is_caught(tmp_path, monkeypatch):
         verify_bundle(bundles[0],
                       hmac_key=os.environ.get("TRUST_SIGNING_KEY"),
                       out=io.StringIO())
+
+
+# ---- pqcrypto API generations (upstream 1.0.0, released 2026-08-15) --------
+# pqcrypto renamed generate_keypair() -> keygen() AND changed how a valid
+# signature is reported:
+#     0.4.0  verify(valid) -> True     verify(invalid) -> False
+#     1.0.0  verify(valid) -> None     verify(invalid) -> raises
+# bool(verify(...)) therefore turned every VALID signature into False under
+# 1.0.0. These stub both generations so the shim cannot regress against either.
+
+class _FakeV04:
+    """pqcrypto 0.x: bool-returning verify."""
+    @staticmethod
+    def generate_keypair(): return (b"pk-0x", b"sk-0x")
+    @staticmethod
+    def sign(sk, data): return b"sig-0x"
+    @staticmethod
+    def verify(pk, data, sig): return sig == b"sig-0x"
+
+
+class _InvalidSignatureError(Exception):
+    pass
+
+
+class _FakeV10:
+    """pqcrypto 1.x: returns None on success, raises on failure."""
+    @staticmethod
+    def keygen(): return (b"pk-1x", b"sk-1x")
+    @staticmethod
+    def sign(sk, data, context=None, hash_algorithm=None): return b"sig-1x"
+    @staticmethod
+    def verify(pk, data, sig, context=None, hash_algorithm=None):
+        if sig != b"sig-1x":
+            raise _InvalidSignatureError("bad signature")
+        return None
+
+
+@pytest.mark.parametrize("fake,good,bad", [
+    (_FakeV04, b"sig-0x", b"forged"),
+    (_FakeV10, b"sig-1x", b"forged"),
+])
+def test_mldsa_shim_handles_both_pqcrypto_generations(monkeypatch, fake, good, bad):
+    from air_blackbox.gate import receipt as R
+    monkeypatch.setattr(R, "_MLDSA_PROVIDER", "pqcrypto")
+    monkeypatch.setattr(R, "_pqclean_mldsa65", fake, raising=False)
+
+    pk, sk = R.mldsa_generate_keypair()
+    assert pk and sk, "keygen must work under both API generations"
+    assert R.mldsa_sign(sk, b"msg") == good
+
+    # The regression that matters: a VALID signature must read as valid.
+    assert R.mldsa_verify(pk, b"msg", good) is True
+    assert R.mldsa_verify(pk, b"msg", bad) is False
+
+
+def test_mldsa_keygen_names_the_problem_if_neither_api_exists(monkeypatch):
+    class _Alien:
+        pass
+    from air_blackbox.gate import receipt as R
+    monkeypatch.setattr(R, "_MLDSA_PROVIDER", "pqcrypto")
+    monkeypatch.setattr(R, "_pqclean_mldsa65", _Alien, raising=False)
+    with pytest.raises(RuntimeError, match="neither keygen"):
+        R.mldsa_generate_keypair()


### PR DESCRIPTION
## What does this PR do?

Fixes `python-test-pqc`, which is now failing on **every** PR — including ones that touch no Python at all. It surfaced on #84 (two files under `docs/`) but the cause is upstream, not that PR.

`pqcrypto 1.0.0` was published **2026-08-15**. `pyproject.toml` declares `pqcrypto>=0.4.0` with no upper bound, so CI resolved it and:

```
AttributeError: module 'pqcrypto.sign.ml_dsa_65' has no attribute 'generate_keypair'
```

## Two breaking changes, not one

Verified side by side against both versions actually installed, rather than read off a changelog:

| | keygen | `verify(valid)` | `verify(invalid)` |
|---|---|---|---|
| **0.4.0** | `generate_keypair()` | `True` | `False` |
| **1.0.0** | `keygen()` | `None` | raises |

The rename is the loud one. **The second is the dangerous one.**

This module did `bool(verify(...))`. Under 1.0.0 a *valid* signature returns `None`, and `bool(None)` is `False` — so **every genuine ML-DSA-65 receipt would have read as invalid.** Mass apparent tampering, in the component whose entire job is telling the truth about tampering.

It fails *closed*, so no forged signature would ever have been accepted. But the post-quantum path would have been unusable while looking like an attack in progress.

**The crash was masking it.** The process died at keygen before `verify` was ever reached. Fixing only the rename — which is what the traceback asks for — would have shipped the silent failure. A negative control confirms it: with the keygen fix alone, a valid signature reads `False`.

## The fix

Both names resolved at call time; `verify` treats *returned without raising* as success and only trusts a returned value when the provider returns an actual `bool`.

**No version pin.** 1.0.0 is the current release, and pinning a cryptographic dependency backwards to dodge an API change is the wrong direction for this library in particular.

## Type of change
- [x] Bug fix
- [ ] New compliance check
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Trust layer integration

## EU AI Act articles affected

No change to any check. Affects the ML-DSA-65 (FIPS 204) signing path referenced under Article 12 record-keeping — restoring it to working order.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility

Backward compatibility is the point: 0.4.0 and 1.0.0 both work, and signatures interoperate — AIR's own signer produces 3309-byte signatures under each, verifiable by the other.

## Additional notes

Tests stub both API generations so neither can regress, plus a case asserting a clear `RuntimeError` if a future version exposes neither name — better than another `AttributeError` from inside the crypto layer.

**405 passing.**

Two things worth flagging:

- Anyone who ran `pip install "air-blackbox[pqc]"` today got a broken post-quantum signer. This is worth a patch release rather than waiting for the next scheduled one.
- #83 (`uv.lock`) would have pinned `pqcrypto 0.4.0` and prevented this, but CI installs with pip and does not read the lock. That is the argument for eventually moving CI to `uv sync --locked` — noted, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_