### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-08-15
+
+The urgent line: **`pip install "air-blackbox[pqc]"` was broken for anyone who
+installed it on 2026-08-15**, the day `pqcrypto` 1.0.0 shipped. This release
+fixes it and gathers everything merged since 1.14.0 — the external red-team of
+the evidence verifier, the server-to-server ingest path, and a set of honest
+corrections to claims that overstated coverage.
+
+**Fixed**
+- **Post-quantum signing under `pqcrypto` 1.x.** `pqcrypto` 1.0.0 renamed
+  `generate_keypair()` to `keygen()` *and* changed `verify()` to return `None`
+  on success and raise on failure. The verifier did `bool(verify(...))`, so a
+  **valid** ML-DSA-65 signature read as `False` — every genuine post-quantum
+  receipt would have looked tampered. It failed closed (no forgery accepted),
+  but the path was unusable. Both API generations are now supported and
+  signatures interoperate. Anyone on 1.14.0 with the `pqc` extra should
+  upgrade. (#85)
+- **The README no longer claims EU AI Act Article 13.** No check ever
+  implemented it; the only reference was a demo table. A test now fails the
+  build if the documented article set and the implemented one disagree in
+  either direction. (#82)
+- **US state hiring-law findings are no longer labelled as EU AI Act articles.**
+  Illinois HB 3773, NYC LL144 and California FEHA findings were filed under
+  `article=16` (EU AI Act provider obligations). They now carry their own
+  framework. Separately, every section heading in the exported PDF was
+  rendering as a bare "Article " from a wrong dictionary key. (#81)
+- **Export no longer times out on the interactive path**, and the ingesting
+  tenant can export its own evidence. (#78)
+
+**Security**
+- **The evidence verifier was adversarially red-teamed: 75 attacks, 17
+  confirmed breaks, all addressed.** Highlights, each with a negative-control
+  test: a forged member could be smuggled past the signature via a duplicate
+  ZIP entry or a payload disguised as a directory; three compliance counts
+  (including `adverse_decisions_missing_reviewer`, the number an auditor reads
+  first) were declared but never recomputed; the public transparency-log
+  receipt was checked only against a key it carried, never against the log. The
+  full write-up, including the limits that remain, is published in
+  [docs/security/red-team-2026-08.md](docs/security/red-team-2026-08.md). (#81)
+
+**Added**
+- **`air-evidence verify --expect-key <fingerprint>`** pins the expected
+  issuer. Unpinned or unanchored bundles now report
+  `VERIFIED (UNATTRIBUTED, UNWITNESSED)` rather than a bare pass, and
+  `--strict` exits non-zero instead of reporting. `--rekor-verify` fetches the
+  transparency-log entry and confirms it matches. (#81)
+- **`/ingest`: a server-to-server event intake** for applications that cannot
+  own the audit chain themselves. Authenticated, tenant-scoped, single-writer
+  by design; returns a signed receipt id per event. See
+  [docs/guides/ingest-integration.md](docs/guides/ingest-integration.md).
+  (#76, #79)
+- **Adverse-decision reviewer gaps are counted separately from engine
+  outputs** in the evidence manifest, so a missing human reviewer on a
+  rejection is no longer buried inside routine scoring volume. (#80)
+- US AI-law references updated to the current statutes — Colorado SB 26-189
+  (SB 24-205 was repealed), Illinois HB 3773, California FEHA ADS. (#75)
+
 ## [1.14.0] - 2026-08-04
 
 First release since 1.13.2. Everything below was already merged to `main` but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "air-blackbox"
-version = "1.14.0"
+version = "1.15.0"
 description = "AI governance control plane - compliance, inventory, incident response, and audit for AI agents"
 readme = "sdk/README.md"
 license = "Apache-2.0"

--- a/sdk/air_blackbox/__init__.py
+++ b/sdk/air_blackbox/__init__.py
@@ -11,7 +11,7 @@ One install. Four commands. 79% automated compliance.
     air-blackbox export      # Signed evidence bundle for auditors
 """
 
-__version__ = "1.14.0"
+__version__ = "1.15.0"
 __all__ = ["AirBlackbox", "AirTrust"]
 
 


### PR DESCRIPTION
## What this does

Bumps to **1.15.0** and writes the changelog, so the pqcrypto fix and everything else merged since 1.14.0 can reach PyPI.

## Why 1.15.0 and not 1.14.1

I called this a "patch" earlier — I was wrong. Since 1.14.0 the following **new backwards-compatible features** merged, and this project follows semver:

- `/ingest` server-to-server intake (#76)
- `air-evidence verify --expect-key` / `--strict` / `--rekor-verify` (#81)
- adverse-vs-engine reviewer split in the manifest (#80)

New features → minor bump. Calling it 1.14.1 would understate what ships.

## The urgent part

`pqcrypto` 1.0.0 shipped **2026-08-15** and broke `pip install "air-blackbox[pqc]"` for anyone installing that day. 1.14.0 carries the latent `bool(verify(...))` bug that 1.0.0 exposes, so the fix (#85) has to reach PyPI — being green on `main` isn't enough.

## Verified against the release gates locally

Built the 1.15.0 artifact and ran what `release.yml` runs:

```
built = 1.15.0                          # tag-match gate
air-blackbox            -> air_blackbox.cli:main                OK
air-blackbox-comply-strict -> ...precompile:main               OK
air-blackbox-mcp        -> air_blackbox.mcp_server:main         OK
air-evidence            -> air_blackbox.evidence_verify:main    OK
pqc signer verifies valid / rejects forged, against pqcrypto 1.0.0   OK
```

That last line is the exact combination that was broken this morning.

## Changes since 1.14.0

Fixed: pqcrypto 1.x (#85), Article 13 overclaim (#82), US-law findings mislabelled as EU articles + blank PDF headings (#81), export timeout (#78).
Security: evidence verifier red-teamed — 75 attacks, 17 breaks, all addressed, [published](docs/security/red-team-2026-08.md) (#81).
Added: `--expect-key` / `--strict` / `--rekor-verify` (#81), `/ingest` (#76, #79), reviewer split (#80), current US-law citations (#75).

## Type of change
- [x] Bug fix
- [ ] New compliance check
- [ ] New feature
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Trust layer integration

## EU AI Act articles affected

No change to any check — a release of already-merged work.

## Checklist
- [x] I have tested this locally with `air-blackbox comply --scan . -v`
- [x] Existing tests still pass
- [x] I have added/updated docstrings where needed
- [x] My changes do not break backward compatibility

## How the publish happens

Merging this does **not** publish. Publishing is triggered by creating a **GitHub Release on tag `v1.15.0`**, which runs `release.yml`: build → verify base install → verify full install → Trusted Publishing to PyPI (no stored token).

**After merge**, cut the release. If you'd rather I create it, say so — otherwise:

```bash
git tag v1.15.0 && git push origin v1.15.0
gh release create v1.15.0 --title "1.15.0" --notes-from-tag
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn

---
_Generated by [Claude Code](https://claude.ai/code/session_01JaqYtxfTuRheY223QQSKFn)_